### PR TITLE
chore: update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
+*.ts linguist-language=TypeScript
+*.tsx linguist-language=TypeScript
 **/test/**/*.js linguist-detectable=false
 *.snap.txt text diff=markdown linguist-language=Markdown -linguist-documentation=false -linguist-detectable=false
 * text=auto eol=lf


### PR DESCRIPTION
force `.ts` & `.tsx` to be recognized as TypeScript