### PR TITLE
feat(luna-stage): extract LynxStage integration and implement useLynxStage

### DIFF
--- a/packages/luna-stage/package.json
+++ b/packages/luna-stage/package.json
@@ -47,6 +47,7 @@
     "tailwind-merge": "catalog:tailwind"
   },
   "devDependencies": {
+    "@lynx-js/web-core": "catalog:lynx",
     "@rsbuild/plugin-react": "catalog:rsbuild",
     "@rslib/core": "catalog:rslib",
     "@types/react": "catalog:react18",

--- a/packages/luna-stage/package.json
+++ b/packages/luna-stage/package.json
@@ -43,6 +43,7 @@
     "build": "rslib build"
   },
   "dependencies": {
+    "@dugyu/luna-core": "workspace:*",
     "clsx": "catalog:utils",
     "tailwind-merge": "catalog:tailwind"
   },
@@ -57,6 +58,7 @@
     "typescript": "catalog:ts"
   },
   "peerDependencies": {
+    "@lynx-js/web-core": ">=0.20.0",
     "motion": ">=12.23.16",
     "react": ">=18.0.0",
     "react-dom": ">=18.0.0"

--- a/packages/luna-stage/src/components/lynx-stage/index.ts
+++ b/packages/luna-stage/src/components/lynx-stage/index.ts
@@ -4,3 +4,9 @@
 
 export { LynxStage } from './lynx-stage';
 export type { LynxStageProps } from './lynx-stage';
+
+export { useLynxStage } from './use-lynx-stage';
+export type { UseLynxStageOptions, UseLynxStageResult } from './use-lynx-stage';
+
+export { LunaLynxStage } from './luna-lynx-stage';
+export type { LunaLynxStageProps } from './luna-lynx-stage';

--- a/packages/luna-stage/src/components/lynx-stage/index.ts
+++ b/packages/luna-stage/src/components/lynx-stage/index.ts
@@ -1,0 +1,6 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+export { LynxStage } from './lynx-stage';
+export type { LynxStageProps } from './lynx-stage';

--- a/packages/luna-stage/src/components/lynx-stage/luna-lynx-stage.tsx
+++ b/packages/luna-stage/src/components/lynx-stage/luna-lynx-stage.tsx
@@ -1,0 +1,77 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type React from 'react';
+import { useMemo } from 'react';
+
+import type { LunaThemeKey, LunaThemeVariant } from '@dugyu/luna-core';
+
+import {
+  CONTAINER_STYLE,
+  DEFAULT_GROUP_ID,
+  LYNX_VIEW_STYLE,
+} from './lynx-stage-constants';
+import type { UseLynxStageOptions } from './use-lynx-stage';
+import { useLynxStage } from './use-lynx-stage';
+import type { LynxGlobalProps } from '../../types/lynx-view';
+
+export type LunaLynxStageProps =
+  & Omit<UseLynxStageOptions, 'globalProps' | 'bundleBaseUrl'>
+  & {
+    /** LUNA theme key, e.g. `'luna-light'`, `'lunaris-dark'`. */
+    lunaTheme?: LunaThemeKey;
+    /** LUNA theme variant, e.g. `'luna'`, `'lunaris'`. */
+    lunaThemeVariant?: LunaThemeVariant;
+    /**
+     * Additional global props to inject alongside LUNA theme props.
+     * Merged with the LUNA props — LUNA props take precedence on key conflicts.
+     */
+    extraGlobalProps?: LynxGlobalProps;
+    /**
+     * Base URL for bundle assets. Must end with a trailing slash.
+     * The resolved bundle URL is: `${bundleBaseUrl}${entry}.web.bundle`
+     * @defaultValue '/'
+     */
+    bundleBaseUrl?: string;
+    /**
+     * Shared Lynx worker group ID. Defaults to 7.
+     * Override to isolate workers between unrelated view groups.
+     */
+    groupId?: number;
+  };
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function LunaLynxStage({
+  lunaTheme = 'luna-light',
+  lunaThemeVariant = 'luna',
+  extraGlobalProps,
+  groupId = DEFAULT_GROUP_ID,
+  bundleBaseUrl = '/',
+  ...stageOptions
+}: LunaLynxStageProps): React.ReactNode {
+  const globalProps = useMemo<LynxGlobalProps>(() => ({
+    ...(extraGlobalProps ?? {}),
+    lunaTheme,
+    lunaThemeVariant,
+  }), [extraGlobalProps, lunaTheme, lunaThemeVariant]);
+
+  const { lynxViewRef, containerRef } = useLynxStage({
+    ...stageOptions,
+    globalProps,
+    bundleBaseUrl,
+  });
+
+  return (
+    <div ref={containerRef} style={CONTAINER_STYLE}>
+      <lynx-view
+        ref={lynxViewRef}
+        style={LYNX_VIEW_STYLE}
+        lynx-group-id={groupId}
+        transform-vh={true}
+        transform-vw={true}
+      />
+    </div>
+  );
+}

--- a/packages/luna-stage/src/components/lynx-stage/lynx-stage-constants.ts
+++ b/packages/luna-stage/src/components/lynx-stage/lynx-stage-constants.ts
@@ -1,0 +1,25 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { CSSProperties } from 'react';
+
+import type { CSSVarProperties } from '../../types/lynx-view';
+
+export const LYNX_VIEW_STYLE: CSSProperties & CSSVarProperties = {
+  width: '100%',
+  height: '100%',
+  pointerEvents: 'all',
+  containerType: 'size',
+  '--rpx-unit': 'calc(100cqw / 750)',
+  '--vh-unit': '1cqh',
+  '--vw-unit': '1cqw',
+};
+
+export const CONTAINER_STYLE: CSSProperties = {
+  position: 'relative',
+  width: '100%',
+  height: '100%',
+};
+
+export const DEFAULT_GROUP_ID = 7;

--- a/packages/luna-stage/src/components/lynx-stage/lynx-stage.tsx
+++ b/packages/luna-stage/src/components/lynx-stage/lynx-stage.tsx
@@ -2,60 +2,31 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import type { LynxViewElement as LynxView } from '@lynx-js/web-core/client';
-import type React from 'react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
 
-import { useContainerResize } from '../../hooks/use-container-resize.js';
+import {
+  CONTAINER_STYLE,
+  DEFAULT_GROUP_ID,
+  LYNX_VIEW_STYLE,
+} from './lynx-stage-constants';
+import { useLynxStage } from './use-lynx-stage';
+import type { UseLynxStageOptions } from './use-lynx-stage';
+import '../../types/lynx-view';
 
-// ─── JSX augmentation ────────────────────────────────────────────────────────
-
-declare global {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
-  namespace JSX {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-    interface IntrinsicElements {
-      'lynx-view': React.DetailedHTMLProps<LynxViewAttributes, HTMLElement>;
-    }
-  }
-}
-
-type LynxViewAttributes = React.HTMLAttributes<HTMLElement> & {
-  'lynx-group-id'?: number;
-  'transform-vh'?: boolean;
-  'transform-vw'?: boolean;
-};
-
-// ─── Types ────────────────────────────────────────────────────────────────────
-
-type CSSVarProperties = Record<`--${string}`, string | number>;
-
-export type LynxStageProps = {
+export type LynxStageProps = Omit<UseLynxStageOptions, 'bundleBaseUrl'> & {
   /**
    * Base URL for bundle assets. Must end with a trailing slash.
    * The resolved bundle URL is: `${bundleBaseUrl}${entry}.web.bundle`
+   * @defaultValue '/'
    */
-  bundleBaseUrl: string;
-  /**
-   * Entry name for the Lynx bundle.
-   */
-  entry: string;
-  /**
-   * Called once when the Lynx runtime has loaded and the view has rendered.
-   */
-  onReady?: () => void;
-  /**
-   * Called when an error occurs during runtime load, template fetch, or rendering.
-   */
-  onError?: (error: string) => void;
+  bundleBaseUrl?: string;
   /**
    * Shared Lynx worker group ID. Defaults to 7.
    * Override to isolate workers between unrelated view groups.
+   * @defaultValue 7
    */
   groupId?: number;
 };
-
-// ─── Constants ────────────────────────────────────────────────────────────────
 
 // Container-relative unit hooks for Lynx runtime:
 // - `containerType: 'size'` enables `cqw/cqh` units based on the host element box.
@@ -63,264 +34,17 @@ export type LynxStageProps = {
 // - `--rpx-unit` aligns `rpx` scaling with a 750-wide design baseline (mobile-like behavior).
 // Note: web-core already applies `contain: content` internally; combined with `containerType: 'size'`
 // this effectively behaves like `contain: strict` without us overriding containment explicitly.
-const LYNX_VIEW_STYLE: React.CSSProperties & CSSVarProperties = {
-  width: '100%',
-  height: '100%',
-  containerType: 'size',
-  '--rpx-unit': 'calc(100cqw / 750)',
-  '--vh-unit': '1cqh',
-  '--vw-unit': '1cqw',
-};
-
-const CONTAINER_STYLE: React.CSSProperties = {
-  position: 'relative',
-  width: '100%',
-  height: '100%',
-};
-
-const DEFAULT_GROUP_ID = 7;
-
-// Pre-compiled regex for webpack public path rewriting in customTemplateLoader.
-// Matches .p=\"<anything>\" — handles empty, single-char, and multi-char paths.
-const WEBPACK_PUBLIC_PATH_RE = /\.p=\\"[^"]*\\"/g;
-
-// ─── Runtime singleton ────────────────────────────────────────────────────────
-
-// Shared promise so multiple LynxStage instances don't duplicate the dynamic import.
-let runtimeReady: Promise<void> | null = null;
-
-function ensureRuntime(): Promise<void> {
-  return (runtimeReady ??= import('@lynx-js/web-core/client').then(() => {
-    /* side-effect only: registers <lynx-view> custom element */
-  }));
-}
-
-type LynxViewWithTemplateLoader = LynxView & {
-  customTemplateLoader?: (url: string) => Promise<unknown>;
-};
-
-function isPlainRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function LynxStage({
   bundleBaseUrl,
-  entry,
-  onReady,
-  onError,
   groupId = DEFAULT_GROUP_ID,
-}: LynxStageProps): React.ReactNode {
-  const lynxViewRef = useRef<LynxView>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  const [ready, setReady] = useState(false);
-  const [dimsReady, setDimsReady] = useState(false);
-
-  const renderedRef = useRef(false);
-  const lastUrlRef = useRef<string>('');
-  const containerSizeRef = useRef({ width: 0, height: 0 });
-  const dimsReadyRef = useRef(false);
-
-  const onReadyRef = useRef(onReady);
-  const onErrorRef = useRef(onError);
-  useEffect(() => {
-    onReadyRef.current = onReady;
-  }, [onReady]);
-  useEffect(() => {
-    onErrorRef.current = onError;
-  }, [onError]);
-
-  const reportError = useCallback((msg: string) => {
-    onErrorRef.current?.(msg);
-  }, []);
-
-  // Reset when entry changes
-  useEffect(() => {
-    renderedRef.current = false;
-    lastUrlRef.current = '';
-  }, [entry, bundleBaseUrl]);
-
-  // Load web-core eagerly on mount
-  useEffect(() => {
-    ensureRuntime()
-      .then(() => setReady(true))
-      .catch((err: unknown) => {
-        reportError(
-          `Failed to load Lynx runtime: ${
-            err instanceof Error ? err.message : String(err)
-          }`,
-        );
-      });
-  }, [reportError]);
-
-  // Watch container dimensions — gate URL assignment on non-zero size.
-  // Handles SplitPane collapsed state where size = 0.
-  useContainerResize({
-    ref: containerRef,
-    onResize: ({ width, height }) => {
-      const nextWidth = width ?? 0;
-      const nextHeight = height ?? 0;
-      containerSizeRef.current = { width: nextWidth, height: nextHeight };
-
-      const valid = nextWidth > 0 && nextHeight > 0;
-      if (valid !== dimsReadyRef.current) {
-        dimsReadyRef.current = valid;
-        setDimsReady(valid);
-      }
-    },
+  ...stageOptions
+}: LynxStageProps): ReactNode {
+  const { lynxViewRef, containerRef } = useLynxStage({
+    bundleBaseUrl: bundleBaseUrl ?? '/',
+    ...stageOptions,
   });
-
-  // Set lynx-view dimensions from container.
-  // browserConfig can only be set once — must have valid dimensions.
-  const setDimensions = useCallback((): boolean => {
-    if (!lynxViewRef.current || !containerRef.current) return false;
-
-    const { width, height } = containerSizeRef.current;
-    if (width === 0 || height === 0) return false;
-
-    const pixelRatio = window.devicePixelRatio;
-    lynxViewRef.current.browserConfig = {
-      pixelWidth: Math.round(width * pixelRatio),
-      pixelHeight: Math.round(height * pixelRatio),
-      pixelRatio,
-    };
-    return true;
-  }, []);
-
-  // Assign URL once runtime + dimensions are ready.
-  // `lastUrlRef` prevents redundant assignments that would trigger a reload.
-  // Shadow listener and render detection always re-run on dimsReady toggle,
-  // so collapse → expand correctly re-attaches observers.
-  useEffect(() => {
-    const lynxView = lynxViewRef.current;
-    const containerEl = containerRef.current;
-
-    if (!ready || !dimsReady || !lynxView || !containerEl) {
-      return;
-    }
-
-    const src = `${bundleBaseUrl}${entry}.web.bundle`;
-    const urlAlreadySet = lastUrlRef.current === src;
-
-    const initialized = setDimensions();
-    if (!initialized) return;
-
-    if (!urlAlreadySet) {
-      const tag = `[LynxStage ${entry}]`;
-
-      const view = lynxView as LynxViewWithTemplateLoader;
-      view.customTemplateLoader = async (url: string) => {
-        try {
-          const res = await fetch(url);
-          if (!res.ok) throw new Error(`HTTP ${res.status} loading ${url}`);
-          const text = await res.text();
-
-          // Rewrite webpack's public path so asset URLs (images etc.) resolve
-          // relative to the bundle location, not the page URL.
-          const baseUrl = url.substring(0, url.lastIndexOf('/') + 1);
-          const rewritten = text.replace(
-            WEBPACK_PUBLIC_PATH_RE,
-            `.p=\\"${baseUrl}\\"`,
-          );
-          const parsed: unknown = JSON.parse(rewritten);
-          if (!isPlainRecord(parsed)) {
-            throw new TypeError('Invalid template JSON');
-          }
-          const template = parsed;
-
-          // Workaround: when no template modules reference publicPath (no asset
-          // imports), rspack omits the local webpack runtime from lepusCode and
-          // emits a bare `__webpack_require__` reference. Inject a minimal shim
-          // so the entry-point executor (`__webpack_require__.x`) can run.
-          const lepusCode = template.lepusCode;
-          if (isPlainRecord(lepusCode)) {
-            const root = lepusCode.root;
-            if (
-              typeof root === 'string'
-              && root.includes('__webpack_require__')
-              && !root.includes('function __webpack_require__')
-            ) {
-              lepusCode.root =
-                `var __webpack_require__={p:"${baseUrl}"};${root}`;
-            }
-          }
-          return template;
-        } catch (err) {
-          const msg = `Failed to load template: ${
-            err instanceof Error ? err.message : String(err)
-          }`;
-          console.error(tag, msg);
-          reportError(msg);
-          throw err;
-        }
-      };
-
-      view.url = src;
-      lastUrlRef.current = src;
-    }
-
-    // Shadow root is created asynchronously by web-core after url is set.
-    // Poll until it becomes available, then watch for first child to mark rendered.
-    const el = lynxView as unknown as HTMLElement;
-    let disposed = false;
-    let mo: MutationObserver | undefined;
-
-    const markRendered = () => {
-      if (renderedRef.current) return;
-      renderedRef.current = true;
-      onReadyRef.current?.();
-    };
-
-    const setupShadow = (shadow: ShadowRoot) => {
-      if (shadow.childElementCount > 0) {
-        markRendered();
-      } else {
-        mo = new MutationObserver(() => {
-          if (shadow.childElementCount > 0) {
-            markRendered();
-            mo!.disconnect();
-          }
-        });
-        mo.observe(shadow, { childList: true, subtree: true });
-      }
-    };
-
-    let timer: ReturnType<typeof setTimeout> | undefined;
-
-    if (!renderedRef.current) {
-      const pollStart = performance.now();
-      const pollShadow = () => {
-        if (disposed) return;
-        if (performance.now() - pollStart > 3000) {
-          reportError('Preview timed out: shadow root was not created');
-          return;
-        }
-        const shadow = el.shadowRoot;
-        if (shadow) {
-          setupShadow(shadow);
-        } else {
-          requestAnimationFrame(pollShadow);
-        }
-      };
-      pollShadow();
-
-      timer = setTimeout(() => {
-        if (!renderedRef.current) {
-          reportError(
-            'Preview timed out: rendering did not complete within 5s',
-          );
-        }
-      }, 5000);
-    }
-
-    return () => {
-      disposed = true;
-      if (timer) clearTimeout(timer);
-      mo?.disconnect();
-    };
-  }, [ready, dimsReady, entry, bundleBaseUrl, setDimensions, reportError]);
 
   return (
     <div ref={containerRef} style={CONTAINER_STYLE}>

--- a/packages/luna-stage/src/components/lynx-stage/lynx-stage.tsx
+++ b/packages/luna-stage/src/components/lynx-stage/lynx-stage.tsx
@@ -1,0 +1,336 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { LynxViewElement as LynxView } from '@lynx-js/web-core/client';
+import type React from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { useContainerResize } from '../../hooks/use-container-resize.js';
+
+// ─── JSX augmentation ────────────────────────────────────────────────────────
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace JSX {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+    interface IntrinsicElements {
+      'lynx-view': React.DetailedHTMLProps<LynxViewAttributes, HTMLElement>;
+    }
+  }
+}
+
+type LynxViewAttributes = React.HTMLAttributes<HTMLElement> & {
+  'lynx-group-id'?: number;
+  'transform-vh'?: boolean;
+  'transform-vw'?: boolean;
+};
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type CSSVarProperties = Record<`--${string}`, string | number>;
+
+export type LynxStageProps = {
+  /**
+   * Base URL for bundle assets. Must end with a trailing slash.
+   * The resolved bundle URL is: `${bundleBaseUrl}${entry}.web.bundle`
+   */
+  bundleBaseUrl: string;
+  /**
+   * Entry name for the Lynx bundle.
+   */
+  entry: string;
+  /**
+   * Called once when the Lynx runtime has loaded and the view has rendered.
+   */
+  onReady?: () => void;
+  /**
+   * Called when an error occurs during runtime load, template fetch, or rendering.
+   */
+  onError?: (error: string) => void;
+  /**
+   * Shared Lynx worker group ID. Defaults to 7.
+   * Override to isolate workers between unrelated view groups.
+   */
+  groupId?: number;
+};
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+// Container-relative unit hooks for Lynx runtime:
+// - `containerType: 'size'` enables `cqw/cqh` units based on the host element box.
+// - `--vh-unit/--vw-unit` make `vh/vw` behave like "container viewport" inside `<lynx-view>`.
+// - `--rpx-unit` aligns `rpx` scaling with a 750-wide design baseline (mobile-like behavior).
+// Note: web-core already applies `contain: content` internally; combined with `containerType: 'size'`
+// this effectively behaves like `contain: strict` without us overriding containment explicitly.
+const LYNX_VIEW_STYLE: React.CSSProperties & CSSVarProperties = {
+  width: '100%',
+  height: '100%',
+  containerType: 'size',
+  '--rpx-unit': 'calc(100cqw / 750)',
+  '--vh-unit': '1cqh',
+  '--vw-unit': '1cqw',
+};
+
+const CONTAINER_STYLE: React.CSSProperties = {
+  position: 'relative',
+  width: '100%',
+  height: '100%',
+};
+
+const DEFAULT_GROUP_ID = 7;
+
+// Pre-compiled regex for webpack public path rewriting in customTemplateLoader.
+// Matches .p=\"<anything>\" — handles empty, single-char, and multi-char paths.
+const WEBPACK_PUBLIC_PATH_RE = /\.p=\\"[^"]*\\"/g;
+
+// ─── Runtime singleton ────────────────────────────────────────────────────────
+
+// Shared promise so multiple LynxStage instances don't duplicate the dynamic import.
+let runtimeReady: Promise<void> | null = null;
+
+function ensureRuntime(): Promise<void> {
+  return (runtimeReady ??= import('@lynx-js/web-core/client').then(() => {
+    /* side-effect only: registers <lynx-view> custom element */
+  }));
+}
+
+type LynxViewWithTemplateLoader = LynxView & {
+  customTemplateLoader?: (url: string) => Promise<unknown>;
+};
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function LynxStage({
+  bundleBaseUrl,
+  entry,
+  onReady,
+  onError,
+  groupId = DEFAULT_GROUP_ID,
+}: LynxStageProps): React.ReactNode {
+  const lynxViewRef = useRef<LynxView>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const [ready, setReady] = useState(false);
+  const [dimsReady, setDimsReady] = useState(false);
+
+  const renderedRef = useRef(false);
+  const lastUrlRef = useRef<string>('');
+  const containerSizeRef = useRef({ width: 0, height: 0 });
+  const dimsReadyRef = useRef(false);
+
+  const onReadyRef = useRef(onReady);
+  const onErrorRef = useRef(onError);
+  useEffect(() => {
+    onReadyRef.current = onReady;
+  }, [onReady]);
+  useEffect(() => {
+    onErrorRef.current = onError;
+  }, [onError]);
+
+  const reportError = useCallback((msg: string) => {
+    onErrorRef.current?.(msg);
+  }, []);
+
+  // Reset when entry changes
+  useEffect(() => {
+    renderedRef.current = false;
+    lastUrlRef.current = '';
+  }, [entry, bundleBaseUrl]);
+
+  // Load web-core eagerly on mount
+  useEffect(() => {
+    ensureRuntime()
+      .then(() => setReady(true))
+      .catch((err: unknown) => {
+        reportError(
+          `Failed to load Lynx runtime: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      });
+  }, [reportError]);
+
+  // Watch container dimensions — gate URL assignment on non-zero size.
+  // Handles SplitPane collapsed state where size = 0.
+  useContainerResize({
+    ref: containerRef,
+    onResize: ({ width, height }) => {
+      const nextWidth = width ?? 0;
+      const nextHeight = height ?? 0;
+      containerSizeRef.current = { width: nextWidth, height: nextHeight };
+
+      const valid = nextWidth > 0 && nextHeight > 0;
+      if (valid !== dimsReadyRef.current) {
+        dimsReadyRef.current = valid;
+        setDimsReady(valid);
+      }
+    },
+  });
+
+  // Set lynx-view dimensions from container.
+  // browserConfig can only be set once — must have valid dimensions.
+  const setDimensions = useCallback((): boolean => {
+    if (!lynxViewRef.current || !containerRef.current) return false;
+
+    const { width, height } = containerSizeRef.current;
+    if (width === 0 || height === 0) return false;
+
+    const pixelRatio = window.devicePixelRatio;
+    lynxViewRef.current.browserConfig = {
+      pixelWidth: Math.round(width * pixelRatio),
+      pixelHeight: Math.round(height * pixelRatio),
+      pixelRatio,
+    };
+    return true;
+  }, []);
+
+  // Assign URL once runtime + dimensions are ready.
+  // `lastUrlRef` prevents redundant assignments that would trigger a reload.
+  // Shadow listener and render detection always re-run on dimsReady toggle,
+  // so collapse → expand correctly re-attaches observers.
+  useEffect(() => {
+    const lynxView = lynxViewRef.current;
+    const containerEl = containerRef.current;
+
+    if (!ready || !dimsReady || !lynxView || !containerEl) {
+      return;
+    }
+
+    const src = `${bundleBaseUrl}${entry}.web.bundle`;
+    const urlAlreadySet = lastUrlRef.current === src;
+
+    const initialized = setDimensions();
+    if (!initialized) return;
+
+    if (!urlAlreadySet) {
+      const tag = `[LynxStage ${entry}]`;
+
+      const view = lynxView as LynxViewWithTemplateLoader;
+      view.customTemplateLoader = async (url: string) => {
+        try {
+          const res = await fetch(url);
+          if (!res.ok) throw new Error(`HTTP ${res.status} loading ${url}`);
+          const text = await res.text();
+
+          // Rewrite webpack's public path so asset URLs (images etc.) resolve
+          // relative to the bundle location, not the page URL.
+          const baseUrl = url.substring(0, url.lastIndexOf('/') + 1);
+          const rewritten = text.replace(
+            WEBPACK_PUBLIC_PATH_RE,
+            `.p=\\"${baseUrl}\\"`,
+          );
+          const parsed: unknown = JSON.parse(rewritten);
+          if (!isPlainRecord(parsed)) {
+            throw new TypeError('Invalid template JSON');
+          }
+          const template = parsed;
+
+          // Workaround: when no template modules reference publicPath (no asset
+          // imports), rspack omits the local webpack runtime from lepusCode and
+          // emits a bare `__webpack_require__` reference. Inject a minimal shim
+          // so the entry-point executor (`__webpack_require__.x`) can run.
+          const lepusCode = template.lepusCode;
+          if (isPlainRecord(lepusCode)) {
+            const root = lepusCode.root;
+            if (
+              typeof root === 'string'
+              && root.includes('__webpack_require__')
+              && !root.includes('function __webpack_require__')
+            ) {
+              lepusCode.root =
+                `var __webpack_require__={p:"${baseUrl}"};${root}`;
+            }
+          }
+          return template;
+        } catch (err) {
+          const msg = `Failed to load template: ${
+            err instanceof Error ? err.message : String(err)
+          }`;
+          console.error(tag, msg);
+          reportError(msg);
+          throw err;
+        }
+      };
+
+      view.url = src;
+      lastUrlRef.current = src;
+    }
+
+    // Shadow root is created asynchronously by web-core after url is set.
+    // Poll until it becomes available, then watch for first child to mark rendered.
+    const el = lynxView as unknown as HTMLElement;
+    let disposed = false;
+    let mo: MutationObserver | undefined;
+
+    const markRendered = () => {
+      if (renderedRef.current) return;
+      renderedRef.current = true;
+      onReadyRef.current?.();
+    };
+
+    const setupShadow = (shadow: ShadowRoot) => {
+      if (shadow.childElementCount > 0) {
+        markRendered();
+      } else {
+        mo = new MutationObserver(() => {
+          if (shadow.childElementCount > 0) {
+            markRendered();
+            mo!.disconnect();
+          }
+        });
+        mo.observe(shadow, { childList: true, subtree: true });
+      }
+    };
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    if (!renderedRef.current) {
+      const pollStart = performance.now();
+      const pollShadow = () => {
+        if (disposed) return;
+        if (performance.now() - pollStart > 3000) {
+          reportError('Preview timed out: shadow root was not created');
+          return;
+        }
+        const shadow = el.shadowRoot;
+        if (shadow) {
+          setupShadow(shadow);
+        } else {
+          requestAnimationFrame(pollShadow);
+        }
+      };
+      pollShadow();
+
+      timer = setTimeout(() => {
+        if (!renderedRef.current) {
+          reportError(
+            'Preview timed out: rendering did not complete within 5s',
+          );
+        }
+      }, 5000);
+    }
+
+    return () => {
+      disposed = true;
+      if (timer) clearTimeout(timer);
+      mo?.disconnect();
+    };
+  }, [ready, dimsReady, entry, bundleBaseUrl, setDimensions, reportError]);
+
+  return (
+    <div ref={containerRef} style={CONTAINER_STYLE}>
+      <lynx-view
+        ref={lynxViewRef}
+        style={LYNX_VIEW_STYLE}
+        lynx-group-id={groupId}
+        transform-vh={true}
+        transform-vw={true}
+      />
+    </div>
+  );
+}

--- a/packages/luna-stage/src/components/lynx-stage/use-lynx-stage.ts
+++ b/packages/luna-stage/src/components/lynx-stage/use-lynx-stage.ts
@@ -1,0 +1,315 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { LynxViewElement as LynxView } from '@lynx-js/web-core/client';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { RefObject } from 'react';
+
+import { useContainerResize } from '../../hooks/use-container-resize';
+import { useEffectEvent } from '../../hooks/use-effect-event';
+import '../../types/lynx-view';
+
+type LynxViewWithExtensions = LynxView & {
+  customTemplateLoader?: (url: string) => Promise<unknown>;
+  onNativeModulesCall?: (
+    name: string,
+    data: unknown,
+    moduleName: string,
+  ) => unknown;
+};
+
+type UpdateGlobalPropsArg = Parameters<LynxView['updateGlobalProps']>[0];
+type GlobalProps = Record<string, unknown>;
+
+export type UseLynxStageOptions = {
+  /**
+   * Base URL for bundle assets. Must end with a trailing slash.
+   * The resolved bundle URL is: `${bundleBaseUrl}${entry}.web.bundle`
+   */
+  bundleBaseUrl: string;
+  /**
+   * Entry name for the Lynx bundle.
+   */
+  entry: string;
+  /**
+   * Global props to inject into the Lynx runtime via `updateGlobalProps`.
+   * Re-injected whenever the object reference changes.
+   */
+  globalProps?: GlobalProps;
+  /**
+   * Called when the Lynx runtime calls a native module.
+   * Return a value to send back to the runtime.
+   */
+  onNativeModulesCall?: (
+    name: string,
+    data: unknown,
+    moduleName: string,
+  ) => unknown;
+  /**
+   * Called once when the view has rendered successfully.
+   */
+  onReady?: () => void;
+  /**
+   * Called when an error occurs during runtime load, template fetch, or rendering.
+   */
+  onError?: (error: string) => void;
+};
+
+export type UseLynxStageResult = {
+  /** Attach to the `<lynx-view>` element. */
+  lynxViewRef: RefObject<LynxView>;
+  /** Attach to the container `<div>` wrapping `<lynx-view>`. */
+  containerRef: RefObject<HTMLDivElement>;
+};
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const WEBPACK_PUBLIC_PATH_RE = /\.p=\\"[^"]*\\"/g;
+
+// ─── Runtime singleton ────────────────────────────────────────────────────────
+
+let runtimeReady: Promise<void> | null = null;
+
+function ensureRuntime(): Promise<void> {
+  return (runtimeReady ??= import('@lynx-js/web-core/client')
+    .then(() => {
+      /* side-effect only: registers <lynx-view> custom element */
+    })
+    .catch((error) => {
+      runtimeReady = null;
+      throw error;
+    }));
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function useLynxStage({
+  bundleBaseUrl,
+  entry,
+  globalProps,
+  onNativeModulesCall,
+  onReady,
+  onError,
+}: UseLynxStageOptions): UseLynxStageResult {
+  const lynxViewRef = useRef<LynxView>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const [ready, setReady] = useState(false);
+  const [dimsReady, setDimsReady] = useState(false);
+
+  const renderedRef = useRef(false);
+  const lastUrlRef = useRef<string>('');
+  const containerSizeRef = useRef({ width: 0, height: 0 });
+  const dimsReadyRef = useRef(false);
+
+  // Stable refs for callbacks — avoids re-running effects on every render
+  const onReadyEvent = useEffectEvent(onReady);
+  const reportError = useEffectEvent<[string]>(onError);
+  const onNativeModulesCallEvent = useEffectEvent(onNativeModulesCall);
+
+  // Reset on entry / base URL change
+  useEffect(() => {
+    renderedRef.current = false;
+    lastUrlRef.current = '';
+  }, [entry, bundleBaseUrl]);
+
+  // Load web-core eagerly on mount
+  useEffect(() => {
+    ensureRuntime()
+      .then(() => setReady(true))
+      .catch((err: unknown) => {
+        reportError(
+          `Failed to load Lynx runtime: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      });
+  }, []);
+
+  // Watch container dimensions — gate URL assignment on non-zero size
+  useContainerResize({
+    ref: containerRef,
+    onResize: ({ width, height }) => {
+      const w = width ?? 0;
+      const h = height ?? 0;
+      containerSizeRef.current = { width: w, height: h };
+      const valid = w > 0 && h > 0;
+      if (valid !== dimsReadyRef.current) {
+        dimsReadyRef.current = valid;
+        setDimsReady(valid);
+      }
+    },
+  });
+
+  // Set browserConfig from container size.
+  // Can only be set once — must have valid dimensions.
+  const setDimensions = useCallback((): boolean => {
+    if (!lynxViewRef.current) return false;
+    const { width, height } = containerSizeRef.current;
+    if (width === 0 || height === 0) return false;
+    const pixelRatio = window.devicePixelRatio;
+    lynxViewRef.current.browserConfig = {
+      pixelWidth: Math.round(width * pixelRatio),
+      pixelHeight: Math.round(height * pixelRatio),
+      pixelRatio,
+    };
+    return true;
+  }, []);
+
+  // Wire up onNativeModulesCall whenever the handler changes
+  useEffect(() => {
+    const view = lynxViewRef.current as LynxViewWithExtensions | null;
+    if (!view) return;
+    view.onNativeModulesCall = (name, data, moduleName) =>
+      onNativeModulesCallEvent(name, data, moduleName);
+  }, [ready]); // re-wire after runtime is ready and ref is populated
+
+  // Inject globalProps whenever they change
+  useEffect(() => {
+    if (!globalProps || !lynxViewRef.current || !renderedRef.current) return;
+    lynxViewRef.current.updateGlobalProps(
+      globalProps as unknown as UpdateGlobalPropsArg,
+    );
+  }, [globalProps]);
+
+  // Assign URL once runtime + dimensions are ready
+  useEffect(() => {
+    const lynxView = lynxViewRef.current as LynxViewWithExtensions | null;
+    if (!ready || !dimsReady || !lynxView) return;
+
+    const normalizedBundleBaseUrl = bundleBaseUrl.endsWith('/')
+      ? bundleBaseUrl
+      : `${bundleBaseUrl}/`;
+    const src = `${normalizedBundleBaseUrl}${entry}.web.bundle`;
+    const urlAlreadySet = lastUrlRef.current === src;
+
+    const initialized = setDimensions();
+    if (!initialized) return;
+
+    if (!urlAlreadySet) {
+      const tag = `[LynxStage ${entry}]`;
+
+      lynxView.customTemplateLoader = async (url: string) => {
+        try {
+          const res = await fetch(url);
+          if (!res.ok) throw new Error(`HTTP ${res.status} loading ${url}`);
+          const text = await res.text();
+
+          const baseUrl = url.substring(0, url.lastIndexOf('/') + 1);
+          const rewritten = text.replace(
+            WEBPACK_PUBLIC_PATH_RE,
+            `.p=\\"${baseUrl}\\"`,
+          );
+          const parsed: unknown = JSON.parse(rewritten);
+          if (!isPlainRecord(parsed)) {
+            throw new TypeError('Invalid template JSON');
+          }
+
+          const lepusCode = parsed.lepusCode;
+          if (isPlainRecord(lepusCode)) {
+            const root = lepusCode.root;
+            if (
+              typeof root === 'string'
+              && root.includes('__webpack_require__')
+              && !root.includes('function __webpack_require__')
+            ) {
+              lepusCode.root =
+                `var __webpack_require__={p:"${baseUrl}"};${root}`;
+            }
+          }
+          return parsed;
+        } catch (err) {
+          const msg = `Failed to load template: ${
+            err instanceof Error ? err.message : String(err)
+          }`;
+          console.error(tag, msg);
+          reportError(msg);
+          throw err;
+        }
+      };
+
+      lynxView.url = src;
+      lastUrlRef.current = src;
+    }
+
+    // Poll for shadow root, then watch for first child to mark rendered
+    const el = lynxView as unknown as HTMLElement;
+    let disposed = false;
+    let mo: MutationObserver | undefined;
+
+    const markRendered = () => {
+      if (renderedRef.current) return;
+      renderedRef.current = true;
+      // Flush globalProps that arrived before render was complete
+      if (globalProps) {
+        lynxView.updateGlobalProps(
+          globalProps as unknown as UpdateGlobalPropsArg,
+        );
+      }
+      onReadyEvent();
+    };
+
+    const setupShadow = (shadow: ShadowRoot) => {
+      if (shadow.childElementCount > 0) {
+        markRendered();
+      } else {
+        mo = new MutationObserver(() => {
+          if (shadow.childElementCount > 0) {
+            markRendered();
+            mo!.disconnect();
+          }
+        });
+        mo.observe(shadow, { childList: true, subtree: true });
+      }
+    };
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    if (!renderedRef.current) {
+      const pollStart = performance.now();
+      const pollShadow = () => {
+        if (disposed) return;
+        if (performance.now() - pollStart > 3000) {
+          reportError('Preview timed out: shadow root was not created');
+          return;
+        }
+        const shadow = el.shadowRoot;
+        if (shadow) setupShadow(shadow);
+        else requestAnimationFrame(pollShadow);
+      };
+      pollShadow();
+
+      timer = setTimeout(() => {
+        if (!renderedRef.current) {
+          reportError(
+            'Preview timed out: rendering did not complete within 5s',
+          );
+        }
+      }, 5000);
+    } else {
+      // Already rendered — re-attach shadow listener for click fix if needed
+      const shadow = el.shadowRoot;
+      if (shadow) setupShadow(shadow);
+    }
+
+    return () => {
+      disposed = true;
+      if (timer) clearTimeout(timer);
+      mo?.disconnect();
+    };
+  }, [
+    ready,
+    dimsReady,
+    entry,
+    bundleBaseUrl,
+    setDimensions,
+    globalProps,
+  ]);
+
+  return { lynxViewRef, containerRef };
+}

--- a/packages/luna-stage/src/index.ts
+++ b/packages/luna-stage/src/index.ts
@@ -13,3 +13,16 @@ export {
 // ─── Static phone mockup ──────────────────────────────────────────────────────
 export { Mockup, MockupContainer } from './components/mockup';
 export type { MockupProps } from './types';
+
+// ─── Lynx stage ────────────────────────────────────────────────────────────────
+export { LynxStage } from './components/lynx-stage';
+export type { LynxStageProps } from './components/lynx-stage';
+
+export { useLynxStage } from './components/lynx-stage';
+export type {
+  UseLynxStageOptions,
+  UseLynxStageResult,
+} from './components/lynx-stage';
+
+export { LunaLynxStage } from './components/lynx-stage';
+export type { LunaLynxStageProps } from './components/lynx-stage';

--- a/packages/luna-stage/src/types/lynx-view.ts
+++ b/packages/luna-stage/src/types/lynx-view.ts
@@ -1,0 +1,23 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { DetailedHTMLProps, HTMLAttributes } from 'react';
+
+type LynxViewAttributes = HTMLAttributes<HTMLElement> & {
+  'lynx-group-id'?: number;
+  'transform-vh'?: boolean;
+  'transform-vw'?: boolean;
+};
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace JSX {
+    interface IntrinsicElements {
+      'lynx-view': DetailedHTMLProps<LynxViewAttributes, HTMLElement>;
+    }
+  }
+}
+
+export type CSSVarProperties = Record<`--${string}`, string | number>;
+export type LynxGlobalProps = Record<string, unknown>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -325,6 +325,9 @@ importers:
 
   packages/luna-stage:
     dependencies:
+      '@dugyu/luna-core':
+        specifier: workspace:*
+        version: link:../core
       clsx:
         specifier: catalog:utils
         version: 2.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: 0.114.4
       version: 0.114.4
     '@lynx-js/web-core':
-      specifier: 0.20.1
-      version: 0.20.1
+      specifier: 0.20.2
+      version: 0.20.2
   lynx-build:
     '@lynx-js/qrcode-rsbuild-plugin':
       specifier: 0.4.6
@@ -254,7 +254,7 @@ importers:
         version: 0.2.2(tailwindcss@3.4.17)
       '@lynx-js/web-core':
         specifier: catalog:lynx
-        version: 0.20.1(@lynx-js/css-serializer@0.1.5)(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)
+        version: 0.20.2(@lynx-js/css-serializer@0.1.5)(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)
       clsx:
         specifier: catalog:utils
         version: 2.1.1
@@ -332,6 +332,9 @@ importers:
         specifier: catalog:tailwind
         version: 2.6.0
     devDependencies:
+      '@lynx-js/web-core':
+        specifier: catalog:lynx
+        version: 0.20.2(@lynx-js/css-serializer@0.1.5)(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)
       '@rsbuild/plugin-react':
         specifier: catalog:rsbuild
         version: 1.4.6(@rsbuild/core@2.0.0-rc.2(@emnapi/core@1.5.0)(@emnapi/runtime@1.5.0)(core-js@3.47.0))
@@ -1429,6 +1432,20 @@ packages:
       tslib:
         optional: true
 
+  '@lynx-js/web-core@0.20.2':
+    resolution: {integrity: sha512-9FlpQSnHOVnxS9yJe2SH2GkO33jf2wDZGGhXBQQRVDP8Hso52wpGE+ik4e4A0g+Pk6RCrXRp3UNA+bo5E96vOQ==}
+    peerDependencies:
+      '@lynx-js/css-serializer': 0.1.5
+      '@lynx-js/lynx-core': 0.1.3
+      tslib: ^2.5.0
+    peerDependenciesMeta:
+      '@lynx-js/css-serializer':
+        optional: true
+      '@lynx-js/lynx-core':
+        optional: true
+      tslib:
+        optional: true
+
   '@lynx-js/web-elements@0.12.0':
     resolution: {integrity: sha512-7z8PQQSDMUWrxoizySOg1pKGIiSDeGGomOr5FV0Tx9gniHNJYx0e7/h6wQmwhyHdAZYyihyaBks88QkX8DRNEw==}
     peerDependencies:
@@ -1439,6 +1456,9 @@ packages:
 
   '@lynx-js/web-worker-rpc@0.20.1':
     resolution: {integrity: sha512-6tXsBghwKRCeF7DXESykzUBvMKBdshF97gFsy8bAYdwt5YphZltp41zBCazV4fzqChp43yeo/CmNuHuu7kJP7w==}
+
+  '@lynx-js/web-worker-rpc@0.20.2':
+    resolution: {integrity: sha512-fbOIku3UsVOa2coXq0z8mJekYgz56614ebwba6q21D96ujgLjJjuowxRmAKQsDC2DFFcf3sAGJd0M0IHsbt9tQ==}
 
   '@lynx-js/webpack-dev-transport@0.2.0':
     resolution: {integrity: sha512-RSy02FSoMsavEn2wna4khSJwT2uGW4XeLduKH8UDT3aCsBNM/rXndUyG6PbwMcywXCeyb8UofkhaQDtJvNJklA==}
@@ -7759,6 +7779,16 @@ snapshots:
       '@lynx-js/lynx-core': 0.1.3
       tslib: 2.8.1
 
+  '@lynx-js/web-core@0.20.2(@lynx-js/css-serializer@0.1.5)(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)':
+    dependencies:
+      '@lynx-js/web-elements': 0.12.0(tslib@2.8.1)
+      '@lynx-js/web-worker-rpc': 0.20.2
+      wasm-feature-detect: 1.8.0
+    optionalDependencies:
+      '@lynx-js/css-serializer': 0.1.5
+      '@lynx-js/lynx-core': 0.1.3
+      tslib: 2.8.1
+
   '@lynx-js/web-elements@0.12.0(tslib@2.8.1)':
     dependencies:
       tslib: 2.8.1
@@ -7766,6 +7796,8 @@ snapshots:
   '@lynx-js/web-rsbuild-server-middleware@0.20.1': {}
 
   '@lynx-js/web-worker-rpc@0.20.1': {}
+
+  '@lynx-js/web-worker-rpc@0.20.2': {}
 
   '@lynx-js/webpack-dev-transport@0.2.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,7 @@ catalogs:
     motion: 12.38.0
   lynx:
     "@lynx-js/react": 0.114.4
-    "@lynx-js/web-core": 0.20.1
+    "@lynx-js/web-core": 0.20.2
   lynx-dev:
     "@lynx-js/preact-devtools": 5.0.1-cf9aef5
     "@lynx-js/types": 3.4.11


### PR DESCRIPTION
- Add `useLynxStage` hook: runtime lazy-load, browserConfig init with dimsReady guard,
  customTemplateLoader with webpack public path rewriting, shadow root polling,
  globalProps injection, onNativeModulesCall wiring
- Add `LynxStage` component as thin shell over useLynxStage
- Add `LunaLynxStage` component: composes useLynxStage with LUNA theme globalProps,
  exposes `onNativeModulesCall` for caller-side bridge event handling