### PR TITLE
feat(luna-studio): extract choreography core from studio app

### DIFF
--- a/.cspell/misc.txt
+++ b/.cspell/misc.txt
@@ -11,3 +11,6 @@ startswith
 svitejs
 tostring
 tsgo
+pointerdown
+pointerup
+pointercancel

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -15,6 +15,7 @@
     "@dugyu/luna-catalog": "workspace:*",
     "@dugyu/luna-core": "workspace:*",
     "@dugyu/luna-stage": "workspace:*",
+    "@dugyu/luna-studio": "workspace:*",
     "@headlessui/react": "^2.2.7",
     "@headlessui/tailwindcss": "^0.2.2",
     "@lynx-js/web-core": "catalog:lynx",

--- a/apps/studio/src/components/choreography/index.ts
+++ b/apps/studio/src/components/choreography/index.ts
@@ -1,7 +1,0 @@
-// Copyright 2026 The Lynx Authors. All rights reserved.
-// Licensed under the Apache License Version 2.0 that can be found in the
-// LICENSE file in the root directory of this source tree.
-
-export { Choreography } from './choreography.tsx';
-export type { ChoreographyProps } from './choreography.tsx';
-export type { StageEvent, StageEventType } from './types';

--- a/apps/studio/src/components/studio/static.tsx
+++ b/apps/studio/src/components/studio/static.tsx
@@ -3,9 +3,9 @@
 // LICENSE file in the root directory of this source tree.
 
 import { Stage, StageContainer } from '@dugyu/luna-stage';
+import { LynxStage } from '@dugyu/luna-stage/lynx';
 
 import { Container } from '@/components/container';
-import { LynxStage } from '@/components/lynx-stage';
 import { StudioFrame } from '@/components/studio-frame';
 
 function StudioStatic() {

--- a/apps/studio/src/components/studio/studio-layout.ts
+++ b/apps/studio/src/components/studio/studio-layout.ts
@@ -2,10 +2,11 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import type { StageEntry, StudioLayout } from '@dugyu/luna-studio';
+
 import type { LunaThemeKey, StudioViewMode } from '@/types';
 
 import { LynxUIComponentsRegistry } from '../../constants/component-data.ts';
-import type { StageEntry, StudioLayout } from '../choreography/types.ts';
 
 const getMeta = LynxUIComponentsRegistry.getMeta;
 

--- a/apps/studio/src/components/studio/studio.tsx
+++ b/apps/studio/src/components/studio/studio.tsx
@@ -4,8 +4,9 @@
 
 import { useState } from 'react';
 
-import { Choreography } from '@/components/choreography';
-import type { LynxRuntimeCall } from '@/components/lynx-stage/studio-luna-lynx-stage';
+import { Choreography } from '@dugyu/luna-studio';
+import type { LynxRuntimeCall } from '@dugyu/luna-studio';
+
 import { MenuBar } from '@/components/menu-bar';
 import { StudioFrame } from '@/components/studio-frame';
 import { STARTING_MODE, STARTING_VARIANT } from '@/constants';

--- a/apps/studio/src/types/index.ts
+++ b/apps/studio/src/types/index.ts
@@ -8,4 +8,4 @@ export type {
   LunaThemeMode,
   LunaThemeVariant,
 } from '@dugyu/luna-core';
-export type { StudioViewMode } from './studio.js';
+export type { StudioViewMode } from '@dugyu/luna-studio';

--- a/apps/studio/tsconfig.json
+++ b/apps/studio/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "paths": {
+      "@dugyu/luna-studio": ["../../packages/luna-studio/src/index.ts"],
       "@/*": ["./src/*"],
     },
     "emitDeclarationOnly": true,
@@ -17,8 +18,14 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
   },
-  "include": ["src", "rsbuild.config.ts", "tailwind.config.ts"],
+  "include": [
+    "src",
+    "../../packages/luna-studio/src",
+    "rsbuild.config.ts",
+    "tailwind.config.ts",
+  ],
   "references": [
     { "path": "../../packages/core/tsconfig.build.json" },
+    { "path": "../../packages/luna-studio/tsconfig.build.json" },
   ],
 }

--- a/apps/studio/tsconfig.json
+++ b/apps/studio/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "paths": {
-      "@dugyu/luna-studio": ["../../packages/luna-studio/src/index.ts"],
       "@/*": ["./src/*"],
     },
     "emitDeclarationOnly": true,
@@ -20,7 +19,6 @@
   },
   "include": [
     "src",
-    "../../packages/luna-studio/src",
     "rsbuild.config.ts",
     "tailwind.config.ts",
   ],

--- a/apps/studio/turbo.json
+++ b/apps/studio/turbo.json
@@ -3,7 +3,12 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "dependsOn": ["@dugyu/luna-stage#build", "@dugyu/luna-core#build", "@dugyu/luna-catalog#build"],
+      "dependsOn": [
+        "@dugyu/luna-studio#build",
+        "@dugyu/luna-stage#build",
+        "@dugyu/luna-core#build",
+        "@dugyu/luna-catalog#build"
+      ],
       "inputs": [
         "src/**",
         "public/**",

--- a/packages/luna-studio/README.md
+++ b/packages/luna-studio/README.md
@@ -119,7 +119,7 @@ type StageEntry = {
   entry: string;
   theme: LunaThemeKey;
   componentId?: string;
-};
+} & Record<string, unknown>;
 ```
 
 Notes:
@@ -246,27 +246,6 @@ This package does **not** yet provide:
 - app-level keyboard bindings
 - demo-specific runtime event parsing
 - a public `lynx-stage` subpath export
-
-## Internal Structure
-
-```text
-packages/luna-studio/
-  src/
-    choreography/
-      choreography.tsx
-      dynamic-view.tsx
-      index.ts
-      types.ts
-      use-controllable-state.ts
-    lynx-stage/
-      studio-luna-lynx-stage.tsx
-      index.ts
-    types/
-      index.ts
-    utils/
-      world.ts
-    index.ts
-```
 
 ## Intended Consumers
 

--- a/packages/luna-studio/README.md
+++ b/packages/luna-studio/README.md
@@ -1,141 +1,278 @@
 # luna-studio
 
-> A multi-stage orchestration terminal built on `@dugyu/luna-stage` — for component library showcases, design system comparisons, and recording-ready layouts.
+`@dugyu/luna-studio` is the reusable choreography core extracted from `apps/studio`.
 
-Use `luna-studio` when you need side-by-side comparison, focus/lineup switching, or a structured presentation environment. For single-frame previews, use [`@dugyu/luna-stage`](../luna-stage) directly.
+It packages the multi-stage layout and Lynx runtime wiring needed for:
+
+- compare / focus / lineup stage arrangements
+- shared theme application across multiple stages
+- host-side stage interaction handling
+- Lynx-to-host runtime callback forwarding
+
+It does **not** currently ship the demo shell from `apps/studio`.
+
+The app-local pieces stay outside this package for now:
+
+- `Studio`
+- `MenuBar`
+- `StudioFrame`
+- keyboard shortcut glue
+- demo-specific runtime handling such as `MoonriseEvent`
+
+If you only need a single device-framed preview, use [`@dugyu/luna-stage`](../luna-stage) directly.
 
 ## Installation
 
 ```sh
-npm i @dugyu/luna-studio @dugyu/luna-stage
+npm i @dugyu/luna-studio @dugyu/luna-stage motion react react-dom
 ```
 
-**Peer dependencies:**
+`luna-studio` depends on `@dugyu/luna-stage` for its rendering primitives.
 
-```sh
-npm i react
-```
+You still need the required Lynx side-effects at your application entry point. See the [Required Lynx Side-effects](../luna-stage#required-lynx-side-effects) section in the `luna-stage` README.
 
-`luna-studio` depends on `luna-stage` for its rendering primitives. You still need to register the Lynx side-effects at your application entry point — see the [Required Lynx Side-effects](../luna-stage#required-lynx-side-effects) section in the `luna-stage` README.
+## What This Package Exports
 
----
+Current public exports from `@dugyu/luna-studio`:
+
+- `Choreography`
+- `ChoreographyProps`
+- `StageEntry`
+- `StudioLayout`
+- `StudioViewMode`
+- `StageEvent`
+- `StageEventType`
+- `LynxRuntimeCall`
+- `LunaThemeKey`
+- `LunaThemeMode`
+- `LunaThemeVariant`
+
+`StudioLunaLynxStage` exists inside the package as an internal adapter, but it is **not** part of the public API yet.
 
 ## Quick Start
 
 ```tsx
-import { Studio } from '@dugyu/luna-studio';
+import { Choreography } from '@dugyu/luna-studio';
+import type { StudioLayout } from '@dugyu/luna-studio';
 
-export default function App() {
+const layout: StudioLayout = {
+  compare: [
+    {
+      id: 'button-light',
+      className: 'flex-1 order-1',
+      entry: 'ActButton',
+      theme: 'luna-light',
+      componentId: 'button',
+    },
+    {
+      id: 'button-dark',
+      className: 'flex-1 order-2',
+      entry: 'ActButton',
+      theme: 'luna-dark',
+      componentId: 'button',
+    },
+  ],
+  focus: [
+    {
+      id: 'button-focus',
+      className: 'col-start-2 col-end-4 row-start-1 row-end-2',
+      entry: 'ActButton',
+      theme: 'luna-light',
+      componentId: 'button',
+    },
+  ],
+  lineup: [
+    {
+      id: 'button-lineup',
+      className: 'col-start-2 col-end-3 row-start-1 row-end-2',
+      entry: 'ActButton',
+      theme: 'lunaris-dark',
+      componentId: 'button',
+    },
+  ],
+};
+
+export function Demo() {
   return (
-    <Studio
-      bundleBaseUrl='/bundles/'
-      recordMode={false}
-    />
+    <div className='size-full'>
+      <Choreography
+        layout={layout}
+        viewMode='compare'
+        themeVariant='lunaris'
+        themeMode='dark'
+      />
+    </div>
   );
 }
 ```
 
-- **`bundleBaseUrl`** — forwarded to each `LunaLynxStage` in the composition; follows the same convention as `luna-stage`.
-- **`recordMode`** — adds layout padding and disables UI chrome so the canvas is clean for screen recording or export.
-- **`stages` / `layouts`** — pass custom stage configurations and layout specs to override the built-in defaults.
+## Core Concepts
 
-## Choreography (Advanced)
+### `StageEntry`
 
-`Choreography` and `DynamicView` are the two layers that power Studio's multi-stage layout:
-
-- **`Choreography`** — the orchestration entry point. Manages which stages are active, owns the view mode state, and handles theme sync and events.
-- **`DynamicView`** — the rendering and animation layer. Reads the current `StudioViewMode` and positions / animates the stage cells accordingly.
-
-```text
-Choreography (state + orchestration)
-  └── DynamicView (layout + animation)
-        └── MotionMockupContainer → MotionPresentation → MotionMockup → LunaLynxStage
-```
-
-### View modes
-
-`StudioViewMode` controls the layout strategy applied by `DynamicView`:
-
-| Mode      | Behavior                                         |
-| --------- | ------------------------------------------------ |
-| `compare` | All stages visible side-by-side at reduced scale |
-| `focus`   | Single stage fills the canvas                    |
-| `lineup`  | Stages arranged in a horizontal strip            |
-
-### Theme events
-
-If `onThemeModeChange` is wired up, `Choreography` propagates theme mode transitions across all active stages simultaneously.
-
-## Default Data
-
-`STAGES` and `BASE_STATUS` are the built-in example configurations used by `Studio` when no `stages` or `layouts` prop is provided.
-
-- They are intentionally minimal — suitable for internal demos and quick exploration.
-- **Do not modify them directly.** Override by passing your own `stages` / `layouts` to `Studio` or `Choreography`.
+`StageEntry` is the per-stage data boundary used by the choreography layer.
 
 ```ts
-import { Studio, STAGES } from '@dugyu/luna-studio';
-
-const myStages = STAGES.map(s => ({
-  ...s,
-  bundleBaseUrl: 'https://cdn.example.com/',
-}));
-
-<Studio stages={myStages} bundleBaseUrl='https://cdn.example.com/' />;
+type StageEntry = {
+  id: string;
+  className: string;
+  entry: string;
+  theme: LunaThemeKey;
+  componentId?: string;
+};
 ```
 
----
+Notes:
 
-## UI Components
+- `id` is used as the React key and motion layout identifier.
+- `className` controls the stage cell placement in the active layout.
+- `entry` is the Lynx bundle entry rendered inside the stage.
+- `theme` is used in `compare` mode.
+- `componentId` is an optional app-defined focus identity.
 
-### `MenuBar`
+### `StudioLayout`
 
-Renders the view mode switcher (`compare` / `focus` / `lineup`). Requires icon assets — see the package's peer dependency notes for icon resolution.
+`StudioLayout` contains one stage list for each built-in presentation mode.
 
-### `StudioFrame`
+```ts
+type StudioLayout = Record<'compare' | 'focus' | 'lineup', StageEntry[]>;
+```
 
-The outermost layout container. Handles canvas sizing, background, and recording padding (activated by `recordMode`). Nest `Choreography` inside it when composing manually.
+### `StudioViewMode`
 
----
+`StudioViewMode` selects which layout slice is active.
 
-## API Surface
+| Mode      | Behavior                                        |
+| --------- | ----------------------------------------------- |
+| `compare` | Shows multiple stages side-by-side              |
+| `focus`   | Places stages into the perspective focus layout |
+| `lineup`  | Places stages into the lineup grid              |
 
-### Components
+## Runtime And Interaction Hooks
 
-| Export         | Description                                  |
-| -------------- | -------------------------------------------- |
-| `Studio`       | Top-level assembly — the default entry point |
-| `Choreography` | Multi-stage orchestration container          |
-| `DynamicView`  | Layout and animation renderer                |
-| `MenuBar`      | View mode switching UI                       |
-| `StudioFrame`  | Canvas container with recording-mode support |
+### `onLynxRuntimeCall`
 
-### Props
+Receives generic runtime callbacks emitted from embedded Lynx content.
 
-| Type                | Description              |
-| ------------------- | ------------------------ |
-| `StudioProps`       | Props for `Studio`       |
-| `ChoreographyProps` | Props for `Choreography` |
-| `DynamicViewProps`  | Props for `DynamicView`  |
+```ts
+type LynxRuntimeCall = {
+  entry: string;
+  channel: string;
+  name: string;
+  data: unknown;
+};
+```
 
-### Data & Config
+This keeps the package surface runtime-neutral:
 
-| Export        | Description                                    |
-| ------------- | ---------------------------------------------- |
-| `STAGES`      | Default stage configuration array              |
-| `BASE_STATUS` | Default view status (active mode, theme state) |
-| `StageMeta`   | Type describing a single stage entry           |
-| `ViewSpec`    | Type describing a layout configuration         |
+- no `bridge` naming in the public API
+- no low-level `moduleName` leak
+- `channel` is the host-facing source identifier
 
----
+### `onStageEvent`
 
-## Who Should Use This?
+Receives host-side interaction events from the outer Web stage container.
 
-`luna-studio` is a **terminal consumer** package — it assembles all lower layers into a ready-to-use presentation environment.
+```ts
+type StageEvent = {
+  type: 'click' | 'pointerdown' | 'pointerup' | 'pointercancel';
+  viewMode: StudioViewMode;
+  stage: StageEntry;
+  nativeEvent: MouseEvent | PointerEvent;
+};
+```
 
-- Internal design system studios
-- Component library documentation demos
-- Multi-variant / multi-theme comparison views
-- Screen recording layouts
+### `interactionTarget`
 
-If you only need a single device-framed preview, reach for `@dugyu/luna-stage` instead — it has no Studio overhead and a smaller API surface.
+Controls where pointer interaction should land:
+
+- `'lynx'`: Lynx content receives pointer interaction
+- `'container'`: the outer Web stage container receives pointer interaction
+
+Example:
+
+```tsx
+<Choreography
+  layout={layout}
+  viewMode='focus'
+  interactionTarget='container'
+  onStageEvent={(event) => {
+    console.log(event.type, event.stage.id);
+  }}
+  onLynxRuntimeCall={(call) => {
+    console.log(call.channel, call.name, call.data);
+  }}
+/>;
+```
+
+## `Choreography` API
+
+`Choreography` is the main public component in this package.
+
+```ts
+type ChoreographyProps = {
+  layout: StudioLayout;
+  viewMode: StudioViewMode;
+  className?: string;
+  interactionTarget?: 'lynx' | 'container';
+  onLynxRuntimeCall?: (call: LynxRuntimeCall) => unknown;
+  onStageEvent?: (event: StageEvent) => void;
+  themeVariant?: LunaThemeVariant;
+  themeMode?: LunaThemeMode;
+};
+```
+
+Behavior notes:
+
+- `themeVariant` defaults to `'lunaris'`
+- `themeMode` defaults to `'dark'`
+- `interactionTarget` defaults to `'lynx'`
+- `layout` is required and should already be fully resolved by the host app
+
+## Scope Of This Extraction
+
+This package currently covers the first extraction target described in `apps/feature-design-spec.md`:
+
+- define public choreography types
+- make `DynamicView` layout-driven
+- move choreography and the Lynx runtime adapter into `packages/luna-studio`
+- make `apps/studio` consume the extracted package
+
+This package does **not** yet provide:
+
+- a top-level `Studio` shell component
+- built-in demo layout data
+- app chrome such as `MenuBar`
+- app-level keyboard bindings
+- demo-specific runtime event parsing
+- a public `lynx-stage` subpath export
+
+## Internal Structure
+
+```text
+packages/luna-studio/
+  src/
+    choreography/
+      choreography.tsx
+      dynamic-view.tsx
+      index.ts
+      types.ts
+      use-controllable-state.ts
+    lynx-stage/
+      studio-luna-lynx-stage.tsx
+      index.ts
+    types/
+      index.ts
+    utils/
+      world.ts
+    index.ts
+```
+
+## Intended Consumers
+
+Use `@dugyu/luna-studio` when you need a reusable multi-stage choreography layer but want to keep your app shell, data, and event handling local:
+
+- documentation sites embedding multiple Lynx entries
+- design system comparison canvases
+- host apps that need both Web-side stage events and Lynx runtime callbacks
+- future `lynx-website` integration

--- a/packages/luna-studio/package.json
+++ b/packages/luna-studio/package.json
@@ -39,15 +39,23 @@
   "scripts": {
     "build": "rslib build"
   },
+  "dependencies": {
+    "@dugyu/luna-core": "workspace:*",
+    "@dugyu/luna-stage": "workspace:*",
+    "clsx": "catalog:utils",
+    "tailwind-merge": "catalog:tailwind"
+  },
   "devDependencies": {
     "@rsbuild/plugin-react": "catalog:rsbuild",
     "@rslib/core": "catalog:rslib",
     "@types/react": "catalog:react18",
+    "motion": "catalog:motion",
     "react": "catalog:react18",
     "react-dom": "catalog:react18",
     "typescript": "catalog:ts"
   },
   "peerDependencies": {
+    "motion": ">=12.23.16",
     "react": ">=18.0.0",
     "react-dom": ">=18.0.0"
   }

--- a/packages/luna-studio/src/choreography/choreography.tsx
+++ b/packages/luna-studio/src/choreography/choreography.tsx
@@ -3,12 +3,17 @@
 // LICENSE file in the root directory of this source tree.
 
 import { LayoutGroup } from 'motion/react';
+import type { JSX } from 'react';
 
-import type { LynxRuntimeCall } from '@/components/lynx-stage';
-import type { LunaThemeMode, LunaThemeVariant, StudioViewMode } from '@/types';
-
-import { DynamicView } from './dynamic-view.tsx';
-import type { StageEvent, StudioLayout } from './types';
+import type { LynxRuntimeCall } from '../lynx-stage';
+import type {
+  LunaThemeMode,
+  LunaThemeVariant,
+  StudioLayout,
+  StudioViewMode,
+} from '../types';
+import { DynamicView } from './dynamic-view';
+import type { StageEvent } from './types';
 
 type ChoreographyProps = {
   /** Fully resolved stage layout used by the choreography layer. */
@@ -28,30 +33,28 @@ type ChoreographyProps = {
   themeMode?: LunaThemeMode;
 };
 
-function Choreography(
-  {
-    layout,
-    viewMode = 'compare',
-    className,
-    interactionTarget,
-    onLynxRuntimeCall,
-    onStageEvent,
-    themeVariant,
-    themeMode,
-  }: ChoreographyProps,
-) {
+function Choreography({
+  layout,
+  viewMode = 'compare',
+  themeVariant = 'lunaris',
+  themeMode = 'dark',
+  interactionTarget = 'lynx',
+  className,
+  onLynxRuntimeCall,
+  onStageEvent,
+}: ChoreographyProps): JSX.Element {
   return (
     <LayoutGroup id='luna-studio'>
       <DynamicView
         layout={layout}
         mode={viewMode}
         key='luna-studio-dynamic-view'
-        className={className}
-        onLynxRuntimeCall={onLynxRuntimeCall}
-        onStageEvent={onStageEvent}
-        themeVariant={themeVariant ?? 'lunaris'}
-        themeMode={themeMode ?? 'dark'}
+        themeVariant={themeVariant}
+        themeMode={themeMode}
         interactionTarget={interactionTarget}
+        {...(className !== undefined ? { className } : {})}
+        {...(onLynxRuntimeCall !== undefined ? { onLynxRuntimeCall } : {})}
+        {...(onStageEvent !== undefined ? { onStageEvent } : {})}
       />
     </LayoutGroup>
   );

--- a/packages/luna-studio/src/choreography/dynamic-view.tsx
+++ b/packages/luna-studio/src/choreography/dynamic-view.tsx
@@ -37,6 +37,10 @@ type RenderData = StageEntry & {
   maskOpacity: number;
 };
 
+type FocusableStageEntry = StageEntry & {
+  componentId: string;
+};
+
 const slidingVariants = {
   initial: { opacity: 0, x: -300 },
   animate: { opacity: 1, x: 0 },
@@ -55,6 +59,10 @@ const DEFAULT_FOCUSED = 'button';
 
 function cn(...inputs: (string | false | null | undefined)[]) {
   return twMerge(clsx(inputs));
+}
+
+function hasComponentId(stage: StageEntry): stage is FocusableStageEntry {
+  return Boolean(stage.componentId);
 }
 
 type DynamicViewProps = {
@@ -133,9 +141,9 @@ function DynamicView({
 
   const rendered: RenderData[] = useMemo(() => {
     const stages = layout[mode];
-    const components = stages.filter(d => d.componentId);
-    const backgroundComponents = components.filter(d =>
-      d.componentId !== focused
+    const components = stages.filter(stage => hasComponentId(stage));
+    const backgroundComponents = components.filter(stage =>
+      stage.componentId !== focused
     );
 
     const mid = (backgroundComponents.length - 1) / 2;
@@ -219,7 +227,7 @@ function DynamicView({
                     studioViewMode={mode}
                     focusedComponent={focused}
                     onLynxRuntimeCall={handleLynxRuntimeCall}
-                    {...(stage.componentId !== undefined
+                    {...(hasComponentId(stage)
                       ? { componentEntry: stage.componentId }
                       : {})}
                   />

--- a/packages/luna-studio/src/choreography/dynamic-view.tsx
+++ b/packages/luna-studio/src/choreography/dynamic-view.tsx
@@ -2,34 +2,37 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import { clsx } from 'clsx';
 import { AnimatePresence } from 'motion/react';
 import type { SpringOptions, Transition } from 'motion/react';
 import type {
+  JSX,
   MouseEvent as ReactMouseEvent,
   PointerEvent as ReactPointerEvent,
 } from 'react';
 import { useMemo, useState } from 'react';
+import { twMerge } from 'tailwind-merge';
 
-import { StudioLunaLynxStage } from '@/components/lynx-stage';
-import type { LynxRuntimeCall } from '@/components/lynx-stage';
 import {
   MotionPresentation,
   MotionStage,
   MotionStageContainer,
-} from '@/components/mockup-motion';
-import type { LunaThemeMode, LunaThemeVariant, StudioViewMode } from '@/types';
-import { cn } from '@/utils';
+} from '@dugyu/luna-stage/motion';
 
-import type { StageEntry, StageEvent, StudioLayout } from './types';
-
-type WorldPos = {
-  x: number;
-  y: number;
-  z: number;
-};
+import { StudioLunaLynxStage } from '../lynx-stage';
+import type { LynxRuntimeCall } from '../lynx-stage';
+import type {
+  LunaThemeMode,
+  LunaThemeVariant,
+  StageEntry,
+  StudioLayout,
+  StudioViewMode,
+} from '../types';
+import type { StageEvent } from './types';
+import { getStageWorldState } from '../utils/world';
 
 type RenderData = StageEntry & {
-  world: WorldPos;
+  world: { x: number; y: number; z: number };
   zIndex: number;
   maskOpacity: number;
 };
@@ -50,7 +53,9 @@ const fitTransition: SpringOptions = { visualDuration: 0.8, bounce: 0.1 };
 
 const DEFAULT_FOCUSED = 'button';
 
-const WORLD_ORIGIN: WorldPos = { x: 0, y: 0, z: 0 };
+function cn(...inputs: (string | false | null | undefined)[]) {
+  return twMerge(clsx(inputs));
+}
 
 type DynamicViewProps = {
   /** Stage layout data for all supported studio view modes. */
@@ -59,9 +64,9 @@ type DynamicViewProps = {
   mode?: StudioViewMode;
   className?: string;
   /** Resolved theme variant passed down to rendered Lynx stages. */
-  themeVariant: LunaThemeVariant;
+  themeVariant?: LunaThemeVariant;
   /** Resolved theme mode passed down to rendered Lynx stages. */
-  themeMode: LunaThemeMode;
+  themeMode?: LunaThemeMode;
   /** Chooses whether pointer interaction is handled by Lynx content or the outer Web container. */
   interactionTarget?: 'lynx' | 'container';
   /** Receives generic runtime calls emitted from the embedded Lynx content. */
@@ -70,18 +75,16 @@ type DynamicViewProps = {
   onStageEvent?: (event: StageEvent) => void;
 };
 
-function DynamicView(
-  {
-    layout,
-    mode = 'compare',
-    className,
-    themeVariant,
-    themeMode,
-    interactionTarget = 'lynx',
-    onLynxRuntimeCall,
-    onStageEvent,
-  }: DynamicViewProps,
-) {
+function DynamicView({
+  layout,
+  mode = 'compare',
+  className,
+  themeVariant = 'lunaris',
+  themeMode = 'dark',
+  interactionTarget = 'lynx',
+  onLynxRuntimeCall,
+  onStageEvent,
+}: DynamicViewProps): JSX.Element {
   const [focused, setFocused] = useState<string>(DEFAULT_FOCUSED);
   const containerInteractive = interactionTarget === 'container';
 
@@ -130,56 +133,34 @@ function DynamicView(
 
   const rendered: RenderData[] = useMemo(() => {
     const stages = layout[mode];
-    const components = stages
-      .filter(d => d.componentId);
+    const components = stages.filter(d => d.componentId);
     const backgroundComponents = components.filter(d =>
       d.componentId !== focused
     );
 
     const mid = (backgroundComponents.length - 1) / 2;
-
     const focusedIndex = components.findIndex(d => d.componentId === focused);
 
-    const items = stages.map((stage) => {
+    return stages.map((stage) => {
       const compOrder = backgroundComponents.findIndex(d =>
         d.componentId === stage.componentId
       );
       const escape = compOrder === -1;
+      const { world, zIndex, maskOpacity } = getStageWorldState({
+        mode,
+        compOrder,
+        mid,
+        focusedIndex,
+        escape,
+      });
 
-      const direction = (compOrder - mid) > 0 ? 1 : -1;
-
-      const theta = ((compOrder - mid) * 20 + direction * focusedIndex * 2)
-        / 180 * Math.PI;
-
-      const world: WorldPos = mode === 'focus'
-        ? {
-          x: escape
-            ? 0
-            : Math.sin(theta) * 600,
-          y: 0,
-          z: escape
-            ? 0
-            : -Math.cos(theta) * 600, // -(1.5 - Math.abs((mid - compOrder) / mid)) * 500,
-        }
-        : WORLD_ORIGIN;
-
-      const zIndex = mode === 'focus'
-        ? (escape ? 100 : Math.ceil(Math.abs(compOrder - mid) * 2))
-        : 0;
-
-      const maskOpacity = mode === 'focus'
-        ? (escape ? 0 : 1 - Math.abs(theta * 2 / Math.PI) * 0.6)
-        : 0;
-
-      const data = {
+      return {
         ...stage,
         world,
-        zIndex: zIndex,
-        maskOpacity: maskOpacity * 0.5,
+        zIndex,
+        maskOpacity,
       };
-      return data;
     });
-    return items;
   }, [focused, layout, mode]);
 
   return (
@@ -198,10 +179,7 @@ function DynamicView(
             <MotionStageContainer
               layoutId={stage.id}
               key={stage.id}
-              className={cn(
-                'h-full',
-                stage.className,
-              )}
+              className={cn('h-full', stage.className)}
               {...getStageContainerEventHandlers(stage)}
               style={{
                 zIndex: stage.zIndex,
@@ -241,7 +219,9 @@ function DynamicView(
                     studioViewMode={mode}
                     focusedComponent={focused}
                     onLynxRuntimeCall={handleLynxRuntimeCall}
-                    componentEntry={stage.componentId}
+                    {...(stage.componentId !== undefined
+                      ? { componentEntry: stage.componentId }
+                      : {})}
                   />
                 </MotionStage>
               </MotionPresentation>
@@ -254,5 +234,4 @@ function DynamicView(
 }
 
 export type { DynamicViewProps };
-
 export { DynamicView };

--- a/packages/luna-studio/src/choreography/index.ts
+++ b/packages/luna-studio/src/choreography/index.ts
@@ -2,4 +2,6 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-export type StudioViewMode = 'compare' | 'focus' | 'lineup';
+export { Choreography } from './choreography';
+export type { ChoreographyProps } from './choreography';
+export type { StageEvent, StageEventType } from './types';

--- a/packages/luna-studio/src/choreography/types.ts
+++ b/packages/luna-studio/src/choreography/types.ts
@@ -1,0 +1,22 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { StageEntry, StudioViewMode } from '../types';
+
+export type StageEventType =
+  | 'click'
+  | 'pointercancel'
+  | 'pointerdown'
+  | 'pointerup';
+
+export type StageEvent = {
+  /** High-level interaction kind observed on the Web stage container. */
+  type: StageEventType;
+  /** Current studio layout mode when the event is emitted. */
+  viewMode: StudioViewMode;
+  /** Stage data associated with the hit container. */
+  stage: StageEntry;
+  /** Original DOM event forwarded from the stage container binding. */
+  nativeEvent: MouseEvent | PointerEvent;
+};

--- a/packages/luna-studio/src/index.ts
+++ b/packages/luna-studio/src/index.ts
@@ -2,6 +2,15 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-export const STUDIO_MODE = 'studio';
-
-export const LUNA_STUDIO_VERIFY_EXPORT = 'luna-studio:verify';
+export { Choreography } from './choreography';
+export type { ChoreographyProps } from './choreography';
+export type { StageEvent, StageEventType } from './choreography/types';
+export type { LynxRuntimeCall } from './lynx-stage';
+export type {
+  LunaThemeKey,
+  LunaThemeMode,
+  LunaThemeVariant,
+  StageEntry,
+  StudioLayout,
+  StudioViewMode,
+} from './types';

--- a/packages/luna-studio/src/lynx-stage/index.ts
+++ b/packages/luna-studio/src/lynx-stage/index.ts
@@ -2,7 +2,6 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-export { LynxStage } from '@dugyu/luna-stage/lynx';
 export { StudioLunaLynxStage } from './studio-luna-lynx-stage';
 export type {
   LynxRuntimeCall,

--- a/packages/luna-studio/src/lynx-stage/studio-luna-lynx-stage.tsx
+++ b/packages/luna-studio/src/lynx-stage/studio-luna-lynx-stage.tsx
@@ -3,10 +3,11 @@
 // LICENSE file in the root directory of this source tree.
 
 import { useMemo } from 'react';
+import type { JSX } from 'react';
 
 import { LunaLynxStage } from '@dugyu/luna-stage/lynx';
 
-import type { LunaThemeKey, LunaThemeVariant, StudioViewMode } from '@/types';
+import type { LunaThemeKey, LunaThemeVariant, StudioViewMode } from '../types';
 
 /**
  * Generic runtime callback payload emitted from Lynx back into the host Web app.
@@ -31,9 +32,7 @@ type StudioLunaLynxStageProps = {
   studioViewMode: StudioViewMode;
   focusedComponent: string;
   /** Receives runtime calls emitted from the embedded Lynx content. */
-  onLynxRuntimeCall?: (
-    call: LynxRuntimeCall,
-  ) => unknown;
+  onLynxRuntimeCall?: (call: LynxRuntimeCall) => unknown;
   componentEntry?: string;
 };
 
@@ -47,7 +46,7 @@ function StudioLunaLynxStage({
   focusedComponent,
   onLynxRuntimeCall,
   componentEntry,
-}: StudioLunaLynxStageProps) {
+}: StudioLunaLynxStageProps): JSX.Element {
   const extraGlobalProps = useMemo(() => ({
     studioViewMode,
     focusedComponent,
@@ -67,13 +66,13 @@ function StudioLunaLynxStage({
 
   return (
     <LunaLynxStage
-      bundleBaseUrl={bundleBaseUrl}
       entry={entry}
-      lunaTheme={lunaTheme}
-      lunaThemeVariant={lunaThemeVariant}
-      interactive={interactive}
       extraGlobalProps={extraGlobalProps}
       onNativeModulesCall={handleNativeModulesCall}
+      {...(bundleBaseUrl !== undefined ? { bundleBaseUrl } : {})}
+      {...(lunaTheme !== undefined ? { lunaTheme } : {})}
+      {...(lunaThemeVariant !== undefined ? { lunaThemeVariant } : {})}
+      {...(interactive !== undefined ? { interactive } : {})}
     />
   );
 }

--- a/packages/luna-studio/src/types/index.ts
+++ b/packages/luna-studio/src/types/index.ts
@@ -2,9 +2,17 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import type { LunaThemeKey, StudioViewMode } from '@/types';
+import type {
+  LunaThemeKey,
+  LunaThemeMode,
+  LunaThemeVariant,
+} from '@dugyu/luna-core';
 
-type StageEntry = {
+export type { LunaThemeKey, LunaThemeMode, LunaThemeVariant };
+
+export type StudioViewMode = 'compare' | 'focus' | 'lineup';
+
+export type StageEntry = {
   /** Stable stage identifier used for layout and event correlation. */
   id: string;
   /** Additional layout className applied to the stage container. */
@@ -18,23 +26,4 @@ type StageEntry = {
 } & Record<string, unknown>;
 
 /** Layout data for the three built-in studio presentation modes. */
-type StudioLayout = Record<StudioViewMode, StageEntry[]>;
-
-type StageEventType =
-  | 'click'
-  | 'pointercancel'
-  | 'pointerdown'
-  | 'pointerup';
-
-type StageEvent = {
-  /** High-level interaction kind observed on the Web stage container. */
-  type: StageEventType;
-  /** Current studio layout mode when the event is emitted. */
-  viewMode: StudioViewMode;
-  /** Stage data associated with the hit container. */
-  stage: StageEntry;
-  /** Original DOM event forwarded from the stage container binding. */
-  nativeEvent: MouseEvent | PointerEvent;
-};
-
-export type { StageEntry, StageEvent, StageEventType, StudioLayout };
+export type StudioLayout = Record<StudioViewMode, StageEntry[]>;

--- a/packages/luna-studio/src/utils/world.ts
+++ b/packages/luna-studio/src/utils/world.ts
@@ -1,0 +1,59 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { StudioViewMode } from '../types';
+
+export type WorldPos = {
+  x: number;
+  y: number;
+  z: number;
+};
+
+export type StageWorldState = {
+  world: WorldPos;
+  zIndex: number;
+  maskOpacity: number;
+};
+
+const WORLD_ORIGIN: WorldPos = { x: 0, y: 0, z: 0 };
+
+export function getStageWorldState({
+  mode,
+  compOrder,
+  mid,
+  focusedIndex,
+  escape,
+}: {
+  mode: StudioViewMode;
+  compOrder: number;
+  mid: number;
+  focusedIndex: number;
+  escape: boolean;
+}): StageWorldState {
+  const direction = (compOrder - mid) > 0 ? 1 : -1;
+  const theta = ((compOrder - mid) * 20 + direction * focusedIndex * 2)
+    / 180 * Math.PI;
+
+  const world: WorldPos = mode === 'focus'
+    ? {
+      x: escape ? 0 : Math.sin(theta) * 600,
+      y: 0,
+      z: escape ? 0 : -Math.cos(theta) * 600,
+    }
+    : WORLD_ORIGIN;
+
+  const zIndex = mode === 'focus'
+    ? (escape ? 100 : Math.ceil(Math.abs(compOrder - mid) * 2))
+    : 0;
+
+  const maskOpacity = mode === 'focus'
+    ? (escape ? 0 : 1 - Math.abs(theta * 2 / Math.PI) * 0.6)
+    : 0;
+
+  return {
+    world,
+    zIndex,
+    maskOpacity: maskOpacity * 0.5,
+  };
+}

--- a/packages/luna-studio/tsconfig.build.json
+++ b/packages/luna-studio/tsconfig.build.json
@@ -13,7 +13,7 @@
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.d.ts"],
   "exclude": ["**/*.test.ts", "**/__tests__/**"],
   "references": [
-    { "path": "../../packages/catalog/tsconfig.build.json" },
-    { "path": "../../packages/core/tsconfig.build.json" }
+    { "path": "../../packages/core/tsconfig.build.json" },
+    { "path": "../../packages/luna-stage/tsconfig.build.json" }
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,29 @@ settings:
 
 catalogs:
   lynx:
+    '@lynx-js/react':
+      specifier: 0.114.4
+      version: 0.114.4
     '@lynx-js/web-core':
       specifier: 0.20.2
       version: 0.20.2
+  lynx-build:
+    '@lynx-js/qrcode-rsbuild-plugin':
+      specifier: 0.4.6
+      version: 0.4.6
+    '@lynx-js/react-rsbuild-plugin':
+      specifier: 0.15.0
+      version: 0.15.0
+    '@lynx-js/rspeedy':
+      specifier: 0.14.1
+      version: 0.14.1
+  lynx-dev:
+    '@lynx-js/preact-devtools':
+      specifier: 5.0.1-cf9aef5
+      version: 5.0.1-cf9aef5
+    '@lynx-js/types':
+      specifier: 3.4.11
+      version: 3.4.11
   motion:
     motion:
       specifier: 12.38.0
@@ -27,13 +47,32 @@ catalogs:
       specifier: 18.3.1
       version: 18.3.1
   rsbuild:
+    '@rsbuild/core':
+      specifier: 1.7.5
+      version: 1.7.5
     '@rsbuild/plugin-react':
       specifier: 1.4.6
       version: 1.4.6
+    '@rsbuild/plugin-type-check':
+      specifier: 1.3.4
+      version: 1.3.4
   rslib:
     '@rslib/core':
       specifier: 0.21.1
       version: 0.21.1
+  tailwind:
+    '@lynx-js/tailwind-preset':
+      specifier: 0.4.0
+      version: 0.4.0
+    rsbuild-plugin-tailwindcss:
+      specifier: 0.2.3
+      version: 0.2.3
+    tailwind-merge:
+      specifier: 2.6.0
+      version: 2.6.0
+    tailwindcss:
+      specifier: 3.4.17
+      version: 3.4.17
   test:
     '@testing-library/jest-dom':
       specifier: 6.9.1
@@ -48,9 +87,19 @@ catalogs:
       specifier: 4.1.5
       version: 4.1.5
   ts:
+    '@types/node':
+      specifier: 24.6.1
+      version: 24.6.1
+    '@typescript/native-preview':
+      specifier: 7.0.0-dev.20251103.1
+      version: 7.0.0-dev.20251103.1
     typescript:
       specifier: 5.9.2
       version: 5.9.2
+  utils:
+    clsx:
+      specifier: 2.1.1
+      version: 2.1.1
 
 importers:
 
@@ -210,6 +259,9 @@ importers:
       '@dugyu/luna-stage':
         specifier: workspace:*
         version: link:../../packages/luna-stage
+      '@dugyu/luna-studio':
+        specifier: workspace:*
+        version: link:../../packages/luna-studio
       '@headlessui/react':
         specifier: ^2.2.7
         version: 2.2.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -301,7 +353,7 @@ importers:
         version: 1.4.6(@rsbuild/core@2.0.0-rc.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(core-js@3.47.0))
       '@rslib/core':
         specifier: catalog:rslib
-        version: 0.21.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(core-js@3.47.0)(typescript@5.9.2)
+        version: 0.21.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20251103.1)(core-js@3.47.0)(typescript@5.9.2)
       '@testing-library/jest-dom':
         specifier: catalog:test
         version: 6.9.1
@@ -334,6 +386,19 @@ importers:
         version: 4.1.5(@types/node@24.6.1)(jsdom@29.0.2)(vite@8.0.10(@types/node@24.6.1)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.2))
 
   packages/luna-studio:
+    dependencies:
+      '@dugyu/luna-core':
+        specifier: workspace:*
+        version: link:../core
+      '@dugyu/luna-stage':
+        specifier: workspace:*
+        version: link:../luna-stage
+      clsx:
+        specifier: catalog:utils
+        version: 2.1.1
+      tailwind-merge:
+        specifier: catalog:tailwind
+        version: 2.6.0
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: catalog:rsbuild
@@ -344,6 +409,9 @@ importers:
       '@types/react':
         specifier: catalog:react18
         version: 18.3.24
+      motion:
+        specifier: catalog:motion
+        version: 12.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: catalog:react18
         version: 18.3.1
@@ -3628,10 +3696,6 @@ packages:
     resolution: {integrity: sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
 
-  css-tree@3.1.0:
-    resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
-    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
-
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
@@ -5211,9 +5275,6 @@ packages:
   mdn-data@2.0.28:
     resolution: {integrity: sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==}
 
-  mdn-data@2.12.2:
-    resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
-
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
@@ -6032,10 +6093,6 @@ packages:
 
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
   preferred-pm@3.1.4:
@@ -8405,7 +8462,7 @@ snapshots:
       '@lynx-js/web-core': 0.20.1(@lynx-js/css-serializer@0.1.5)(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)
       '@lynx-js/webpack-runtime-globals': 0.0.6
       '@rspack/lite-tapable': 1.1.0
-      css-tree: 3.1.0
+      css-tree: 3.2.1
       object.groupby: 1.0.3
     transitivePeerDependencies:
       - '@lynx-js/lynx-core'
@@ -8507,8 +8564,8 @@ snapshots:
 
   '@napi-rs/wasm-runtime@1.0.7':
     dependencies:
-      '@emnapi/core': 1.5.0
-      '@emnapi/runtime': 1.5.0
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
     optional: true
 
@@ -9891,19 +9948,6 @@ snapshots:
       - '@typescript/native-preview'
       - core-js
 
-  '@rslib/core@0.21.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(core-js@3.47.0)(typescript@5.9.2)':
-    dependencies:
-      '@rsbuild/core': 2.0.0-rc.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(core-js@3.47.0)
-      rsbuild-plugin-dts: 0.21.1(@rsbuild/core@2.0.0-rc.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(core-js@3.47.0))(typescript@5.9.2)
-    optionalDependencies:
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-      - '@module-federation/runtime-tools'
-      - '@typescript/native-preview'
-      - core-js
-
   '@rspack/binding-darwin-arm64@1.7.11':
     optional: true
 
@@ -10829,7 +10873,7 @@ snapshots:
 
   browserslist-to-es-version@1.1.1:
     dependencies:
-      browserslist: 4.25.4
+      browserslist: 4.28.2
 
   browserslist@4.25.4:
     dependencies:
@@ -10920,7 +10964,7 @@ snapshots:
   caniuse-api@3.0.0:
     dependencies:
       browserslist: 4.28.2
-      caniuse-lite: 1.0.30001741
+      caniuse-lite: 1.0.30001788
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
 
@@ -11192,16 +11236,16 @@ snapshots:
       semver: 7.7.3
       tinyglobby: 0.2.15
 
-  css-declaration-sorter@7.2.0(postcss@8.5.6):
+  css-declaration-sorter@7.2.0(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
 
   css-minimizer-webpack-plugin@7.0.2(webpack@5.101.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.30
-      cssnano: 7.1.5(postcss@8.5.6)
+      cssnano: 7.1.5(postcss@8.5.10)
       jest-worker: 29.7.0
-      postcss: 8.5.6
+      postcss: 8.5.10
       schema-utils: 4.3.2
       serialize-javascript: 6.0.2
       webpack: 5.101.3
@@ -11219,11 +11263,6 @@ snapshots:
       mdn-data: 2.0.28
       source-map-js: 1.2.1
 
-  css-tree@3.1.0:
-    dependencies:
-      mdn-data: 2.12.2
-      source-map-js: 1.2.1
-
   css-tree@3.2.1:
     dependencies:
       mdn-data: 2.27.1
@@ -11235,49 +11274,49 @@ snapshots:
 
   cssesc@3.0.0: {}
 
-  cssnano-preset-default@7.0.13(postcss@8.5.6):
+  cssnano-preset-default@7.0.13(postcss@8.5.10):
     dependencies:
       browserslist: 4.28.2
-      css-declaration-sorter: 7.2.0(postcss@8.5.6)
-      cssnano-utils: 5.0.1(postcss@8.5.6)
-      postcss: 8.5.6
-      postcss-calc: 10.1.1(postcss@8.5.6)
-      postcss-colormin: 7.0.8(postcss@8.5.6)
-      postcss-convert-values: 7.0.10(postcss@8.5.6)
-      postcss-discard-comments: 7.0.6(postcss@8.5.6)
-      postcss-discard-duplicates: 7.0.2(postcss@8.5.6)
-      postcss-discard-empty: 7.0.1(postcss@8.5.6)
-      postcss-discard-overridden: 7.0.1(postcss@8.5.6)
-      postcss-merge-longhand: 7.0.5(postcss@8.5.6)
-      postcss-merge-rules: 7.0.9(postcss@8.5.6)
-      postcss-minify-font-values: 7.0.1(postcss@8.5.6)
-      postcss-minify-gradients: 7.0.3(postcss@8.5.6)
-      postcss-minify-params: 7.0.7(postcss@8.5.6)
-      postcss-minify-selectors: 7.0.6(postcss@8.5.6)
-      postcss-normalize-charset: 7.0.1(postcss@8.5.6)
-      postcss-normalize-display-values: 7.0.1(postcss@8.5.6)
-      postcss-normalize-positions: 7.0.1(postcss@8.5.6)
-      postcss-normalize-repeat-style: 7.0.1(postcss@8.5.6)
-      postcss-normalize-string: 7.0.1(postcss@8.5.6)
-      postcss-normalize-timing-functions: 7.0.1(postcss@8.5.6)
-      postcss-normalize-unicode: 7.0.7(postcss@8.5.6)
-      postcss-normalize-url: 7.0.1(postcss@8.5.6)
-      postcss-normalize-whitespace: 7.0.1(postcss@8.5.6)
-      postcss-ordered-values: 7.0.2(postcss@8.5.6)
-      postcss-reduce-initial: 7.0.7(postcss@8.5.6)
-      postcss-reduce-transforms: 7.0.1(postcss@8.5.6)
-      postcss-svgo: 7.1.1(postcss@8.5.6)
-      postcss-unique-selectors: 7.0.5(postcss@8.5.6)
+      css-declaration-sorter: 7.2.0(postcss@8.5.10)
+      cssnano-utils: 5.0.1(postcss@8.5.10)
+      postcss: 8.5.10
+      postcss-calc: 10.1.1(postcss@8.5.10)
+      postcss-colormin: 7.0.8(postcss@8.5.10)
+      postcss-convert-values: 7.0.10(postcss@8.5.10)
+      postcss-discard-comments: 7.0.6(postcss@8.5.10)
+      postcss-discard-duplicates: 7.0.2(postcss@8.5.10)
+      postcss-discard-empty: 7.0.1(postcss@8.5.10)
+      postcss-discard-overridden: 7.0.1(postcss@8.5.10)
+      postcss-merge-longhand: 7.0.5(postcss@8.5.10)
+      postcss-merge-rules: 7.0.9(postcss@8.5.10)
+      postcss-minify-font-values: 7.0.1(postcss@8.5.10)
+      postcss-minify-gradients: 7.0.3(postcss@8.5.10)
+      postcss-minify-params: 7.0.7(postcss@8.5.10)
+      postcss-minify-selectors: 7.0.6(postcss@8.5.10)
+      postcss-normalize-charset: 7.0.1(postcss@8.5.10)
+      postcss-normalize-display-values: 7.0.1(postcss@8.5.10)
+      postcss-normalize-positions: 7.0.1(postcss@8.5.10)
+      postcss-normalize-repeat-style: 7.0.1(postcss@8.5.10)
+      postcss-normalize-string: 7.0.1(postcss@8.5.10)
+      postcss-normalize-timing-functions: 7.0.1(postcss@8.5.10)
+      postcss-normalize-unicode: 7.0.7(postcss@8.5.10)
+      postcss-normalize-url: 7.0.1(postcss@8.5.10)
+      postcss-normalize-whitespace: 7.0.1(postcss@8.5.10)
+      postcss-ordered-values: 7.0.2(postcss@8.5.10)
+      postcss-reduce-initial: 7.0.7(postcss@8.5.10)
+      postcss-reduce-transforms: 7.0.1(postcss@8.5.10)
+      postcss-svgo: 7.1.1(postcss@8.5.10)
+      postcss-unique-selectors: 7.0.5(postcss@8.5.10)
 
-  cssnano-utils@5.0.1(postcss@8.5.6):
+  cssnano-utils@5.0.1(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
 
-  cssnano@7.1.5(postcss@8.5.6):
+  cssnano@7.1.5(postcss@8.5.10):
     dependencies:
-      cssnano-preset-default: 7.0.13(postcss@8.5.6)
+      cssnano-preset-default: 7.0.13(postcss@8.5.10)
       lilconfig: 3.1.3
-      postcss: 8.5.6
+      postcss: 8.5.10
 
   csso@5.0.5:
     dependencies:
@@ -12941,8 +12980,6 @@ snapshots:
 
   mdn-data@2.0.28: {}
 
-  mdn-data@2.12.2: {}
-
   mdn-data@2.27.1: {}
 
   media-typer@0.3.0: {}
@@ -13628,166 +13665,166 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-calc@10.1.1(postcss@8.5.6):
+  postcss-calc@10.1.1(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
       postcss-selector-parser: 7.1.1
       postcss-value-parser: 4.2.0
 
-  postcss-colormin@7.0.8(postcss@8.5.6):
+  postcss-colormin@7.0.8(postcss@8.5.10):
     dependencies:
       '@colordx/core': 5.0.3
       browserslist: 4.28.2
       caniuse-api: 3.0.0
-      postcss: 8.5.6
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
-  postcss-convert-values@7.0.10(postcss@8.5.6):
+  postcss-convert-values@7.0.10(postcss@8.5.10):
     dependencies:
       browserslist: 4.28.2
-      postcss: 8.5.6
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
-  postcss-discard-comments@7.0.6(postcss@8.5.6):
+  postcss-discard-comments@7.0.6(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
       postcss-selector-parser: 7.1.1
 
-  postcss-discard-duplicates@7.0.2(postcss@8.5.6):
+  postcss-discard-duplicates@7.0.2(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
 
-  postcss-discard-empty@7.0.1(postcss@8.5.6):
+  postcss-discard-empty@7.0.1(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
 
-  postcss-discard-overridden@7.0.1(postcss@8.5.6):
+  postcss-discard-overridden@7.0.1(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
 
-  postcss-import@15.1.0(postcss@8.5.6):
+  postcss-import@15.1.0(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.10
 
-  postcss-js@4.0.1(postcss@8.5.6):
+  postcss-js@4.0.1(postcss@8.5.10):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.5.6
+      postcss: 8.5.10
 
-  postcss-load-config@4.0.2(postcss@8.5.6):
+  postcss-load-config@4.0.2(postcss@8.5.10):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.8.2
     optionalDependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
 
-  postcss-merge-longhand@7.0.5(postcss@8.5.6):
+  postcss-merge-longhand@7.0.5(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
-      stylehacks: 7.0.9(postcss@8.5.6)
+      stylehacks: 7.0.9(postcss@8.5.10)
 
-  postcss-merge-rules@7.0.9(postcss@8.5.6):
+  postcss-merge-rules@7.0.9(postcss@8.5.10):
     dependencies:
       browserslist: 4.28.2
       caniuse-api: 3.0.0
-      cssnano-utils: 5.0.1(postcss@8.5.6)
-      postcss: 8.5.6
+      cssnano-utils: 5.0.1(postcss@8.5.10)
+      postcss: 8.5.10
       postcss-selector-parser: 7.1.1
 
-  postcss-minify-font-values@7.0.1(postcss@8.5.6):
+  postcss-minify-font-values@7.0.1(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
-  postcss-minify-gradients@7.0.3(postcss@8.5.6):
+  postcss-minify-gradients@7.0.3(postcss@8.5.10):
     dependencies:
       '@colordx/core': 5.0.3
-      cssnano-utils: 5.0.1(postcss@8.5.6)
-      postcss: 8.5.6
+      cssnano-utils: 5.0.1(postcss@8.5.10)
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
-  postcss-minify-params@7.0.7(postcss@8.5.6):
+  postcss-minify-params@7.0.7(postcss@8.5.10):
     dependencies:
       browserslist: 4.28.2
-      cssnano-utils: 5.0.1(postcss@8.5.6)
-      postcss: 8.5.6
+      cssnano-utils: 5.0.1(postcss@8.5.10)
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
-  postcss-minify-selectors@7.0.6(postcss@8.5.6):
+  postcss-minify-selectors@7.0.6(postcss@8.5.10):
     dependencies:
       cssesc: 3.0.0
-      postcss: 8.5.6
+      postcss: 8.5.10
       postcss-selector-parser: 7.1.1
 
-  postcss-nested@6.2.0(postcss@8.5.6):
+  postcss-nested@6.2.0(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
       postcss-selector-parser: 6.1.2
 
-  postcss-normalize-charset@7.0.1(postcss@8.5.6):
+  postcss-normalize-charset@7.0.1(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
 
-  postcss-normalize-display-values@7.0.1(postcss@8.5.6):
+  postcss-normalize-display-values@7.0.1(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-positions@7.0.1(postcss@8.5.6):
+  postcss-normalize-positions@7.0.1(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-repeat-style@7.0.1(postcss@8.5.6):
+  postcss-normalize-repeat-style@7.0.1(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-string@7.0.1(postcss@8.5.6):
+  postcss-normalize-string@7.0.1(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-timing-functions@7.0.1(postcss@8.5.6):
+  postcss-normalize-timing-functions@7.0.1(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-unicode@7.0.7(postcss@8.5.6):
+  postcss-normalize-unicode@7.0.7(postcss@8.5.10):
     dependencies:
       browserslist: 4.28.2
-      postcss: 8.5.6
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-url@7.0.1(postcss@8.5.6):
+  postcss-normalize-url@7.0.1(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-whitespace@7.0.1(postcss@8.5.6):
+  postcss-normalize-whitespace@7.0.1(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
-  postcss-ordered-values@7.0.2(postcss@8.5.6):
+  postcss-ordered-values@7.0.2(postcss@8.5.10):
     dependencies:
-      cssnano-utils: 5.0.1(postcss@8.5.6)
-      postcss: 8.5.6
+      cssnano-utils: 5.0.1(postcss@8.5.10)
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
-  postcss-reduce-initial@7.0.7(postcss@8.5.6):
+  postcss-reduce-initial@7.0.7(postcss@8.5.10):
     dependencies:
       browserslist: 4.28.2
       caniuse-api: 3.0.0
-      postcss: 8.5.6
+      postcss: 8.5.10
 
-  postcss-reduce-transforms@7.0.1(postcss@8.5.6):
+  postcss-reduce-transforms@7.0.1(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
   postcss-selector-parser@6.1.2:
@@ -13800,26 +13837,20 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss-svgo@7.1.1(postcss@8.5.6):
+  postcss-svgo@7.1.1(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
       svgo: 4.0.1
 
-  postcss-unique-selectors@7.0.5(postcss@8.5.6):
+  postcss-unique-selectors@7.0.5(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
       postcss-selector-parser: 7.1.1
 
   postcss-value-parser@4.2.0: {}
 
   postcss@8.5.10:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -14068,13 +14099,6 @@ snapshots:
       '@rsbuild/core': 2.0.0-rc.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(core-js@3.47.0)
     optionalDependencies:
       '@typescript/native-preview': 7.0.0-dev.20251103.1
-      typescript: 5.9.2
-
-  rsbuild-plugin-dts@0.21.1(@rsbuild/core@2.0.0-rc.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(core-js@3.47.0))(typescript@5.9.2):
-    dependencies:
-      '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 2.0.0-rc.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(core-js@3.47.0)
-    optionalDependencies:
       typescript: 5.9.2
 
   rsbuild-plugin-tailwindcss@0.2.3(@rsbuild/core@1.7.5)(tailwindcss@3.4.17):
@@ -14472,10 +14496,10 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  stylehacks@7.0.9(postcss@8.5.6):
+  stylehacks@7.0.9(postcss@8.5.10):
     dependencies:
       browserslist: 4.28.2
-      postcss: 8.5.6
+      postcss: 8.5.10
       postcss-selector-parser: 7.1.1
 
   sucrase@3.35.0:
@@ -14502,7 +14526,7 @@ snapshots:
     dependencies:
       commander: 11.1.0
       css-select: 5.2.2
-      css-tree: 3.1.0
+      css-tree: 3.2.1
       css-what: 6.2.2
       csso: 5.0.5
       picocolors: 1.1.1
@@ -14539,11 +14563,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.6
-      postcss-import: 15.1.0(postcss@8.5.6)
-      postcss-js: 4.0.1(postcss@8.5.6)
-      postcss-load-config: 4.0.2(postcss@8.5.6)
-      postcss-nested: 6.2.0(postcss@8.5.6)
+      postcss: 8.5.10
+      postcss-import: 15.1.0(postcss@8.5.10)
+      postcss-js: 4.0.1(postcss@8.5.10)
+      postcss-load-config: 4.0.2(postcss@8.5.10)
+      postcss-nested: 6.2.0(postcss@8.5.10)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.10
       sucrase: 3.35.0


### PR DESCRIPTION
- create packages/luna-studio as the new home for the reusable choreography core
- move Choreography, DynamicView, and the internal Lynx runtime adapter into the package
- expose StageEntry, StudioLayout, StageEvent, StudioViewMode, and LynxRuntimeCall from the package root
- extract world-position math into a package-local utility
- update apps/studio to consume the extracted package while keeping app-shell concerns local
- leave MenuBar, StudioFrame, keyboard controls, and demo-specific runtime handling in apps/studio
- delete the migrated choreography and lynx-stage implementation from apps/studio
- document the package scope and current usage in the luna-studio README

## Related
- Implementing #103 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `@dugyu/luna-studio` package now exposes the `Choreography` component and public API with types for stage interactions.
  * Added stage event types (`StageEvent`, `StageEventType`) for enhanced event handling.
  * Applied sensible default values for theme and interaction settings.

* **Chores**
  * Updated package dependencies and TypeScript configuration to support the extracted choreography core.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->