### PR TITLE
refactor(luna-studio): data driven stage styling, remove tw and clsx

### DIFF
--- a/apps/studio/src/components/studio/studio-layout-grid.ts
+++ b/apps/studio/src/components/studio/studio-layout-grid.ts
@@ -1,0 +1,275 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type { CSSProperties } from 'react';
+
+import type { StageEntry, StudioLayout } from '@dugyu/luna-studio';
+
+import type { LunaThemeKey, StudioViewMode } from '@/types';
+
+import { LynxUIComponentsRegistry } from '../../constants';
+
+const getMeta = LynxUIComponentsRegistry.getMeta;
+
+type StageCatalogItem = {
+  entry: string;
+  theme: LunaThemeKey;
+  studio?: {
+    component?: {
+      key: string;
+      meta?: ReturnType<typeof getMeta>;
+    };
+  };
+};
+
+type GridSpec = {
+  cols: number;
+  rows: number;
+};
+
+type Cell = {
+  col: number;
+  row: number;
+  colSpan?: number;
+  rowSpan?: number;
+};
+
+const stageCatalog = {
+  Bloom: { entry: 'ActBloom', theme: 'lunaris-light' },
+  MoonRise: {
+    entry: 'ActMoonrise',
+    theme: 'luna-light',
+    studio: {
+      component: {
+        key: 'button',
+        meta: getMeta('button'),
+      },
+    },
+  },
+  MoonRiseDark: { entry: 'ActMoonrise', theme: 'luna-dark' },
+  Switch: {
+    entry: 'ActSwitch',
+    theme: 'lunaris-dark',
+    studio: {
+      component: {
+        key: 'switch',
+        meta: getMeta('switch'),
+      },
+    },
+  },
+  Slider: {
+    entry: 'ActTwoDark',
+    theme: 'luna-dark',
+    studio: {
+      component: {
+        key: 'slider',
+        meta: getMeta('slider'),
+      },
+    },
+  },
+  Radio: {
+    entry: 'ActRadioGroup',
+    theme: 'lunaris-dark',
+    studio: {
+      component: {
+        key: 'radio-group',
+        meta: getMeta('radio-group'),
+      },
+    },
+  },
+  ScrollView: {
+    entry: 'OffstageActScrollView',
+    theme: 'luna-dark',
+    studio: {
+      component: {
+        key: 'scroll-view',
+        meta: getMeta('scroll-view'),
+      },
+    },
+  },
+  FeedList: {
+    entry: 'OffstageActFeedList',
+    theme: 'luna-dark',
+    studio: {
+      component: {
+        key: 'feed-list',
+        meta: getMeta('feed-list'),
+      },
+    },
+  },
+  Swiper: {
+    entry: 'OffstageActSwiper',
+    theme: 'luna-dark',
+    studio: {
+      component: {
+        key: 'swiper',
+        meta: getMeta('swiper'),
+      },
+    },
+  },
+  Popover: {
+    entry: 'OffstageActPopover',
+    theme: 'luna-light',
+    studio: {
+      component: {
+        key: 'popover',
+        meta: getMeta('popover'),
+      },
+    },
+  },
+  Sheet: {
+    entry: 'ActOneDark',
+    theme: 'lunaris-dark',
+    studio: {
+      component: {
+        key: 'sheet',
+        meta: getMeta('sheet'),
+      },
+    },
+  },
+  Dialog: {
+    entry: 'OffstageActDialog',
+    theme: 'luna-dark',
+    studio: {
+      component: {
+        key: 'dialog',
+        meta: getMeta('dialog'),
+      },
+    },
+  },
+  Checkbox: {
+    entry: 'ActCheckbox',
+    theme: 'lunaris-dark',
+    studio: {
+      component: {
+        key: 'checkbox',
+        meta: getMeta('checkbox'),
+      },
+    },
+  },
+  Input: {
+    entry: 'ActTwoDark',
+    theme: 'luna-dark',
+    studio: {
+      component: {
+        key: 'input',
+        meta: getMeta('input'),
+      },
+    },
+  },
+} satisfies Record<string, StageCatalogItem>;
+
+type StageId = keyof typeof stageCatalog;
+
+type ModeLayoutItem = StageId | {
+  id: StageId;
+  cell: Cell;
+};
+
+function cell(
+  col: number,
+  row: number,
+  colSpan = 1,
+  rowSpan = 1,
+): Cell {
+  return { col, row, colSpan, rowSpan };
+}
+
+const modeGrid = {
+  compare: { cols: 4, rows: 1 },
+  focus: { cols: 3, rows: 1 },
+  lineup: { cols: 5, rows: 2 },
+} satisfies Record<StudioViewMode, GridSpec>;
+
+const modeLayout = {
+  // Keep compare array order aligned with the legacy layout to avoid DOM reordering.
+  compare: [
+    { id: 'MoonRiseDark', cell: cell(4, 1) },
+    { id: 'Sheet', cell: cell(2, 1) },
+    { id: 'MoonRise', cell: cell(3, 1) },
+    { id: 'Bloom', cell: cell(1, 1) },
+  ],
+  focus: [
+    { id: 'Radio', cell: cell(2, 1, 2) },
+    { id: 'Switch', cell: cell(2, 1, 2) },
+    { id: 'ScrollView', cell: cell(2, 1, 2) },
+    { id: 'Checkbox', cell: cell(2, 1, 2) },
+    { id: 'FeedList', cell: cell(2, 1, 2) },
+    { id: 'Sheet', cell: cell(2, 1, 2) },
+    { id: 'Swiper', cell: cell(2, 1, 2) },
+    { id: 'Dialog', cell: cell(2, 1, 2) },
+    { id: 'Popover', cell: cell(2, 1, 2) },
+    { id: 'MoonRise', cell: cell(2, 1, 2) },
+    { id: 'Bloom', cell: cell(1, 1) },
+  ],
+  lineup: [
+    { id: 'Radio', cell: cell(5, 1) },
+    { id: 'Switch', cell: cell(1, 1) },
+    { id: 'ScrollView', cell: cell(5, 2) },
+    { id: 'Checkbox', cell: cell(2, 1) },
+    { id: 'FeedList', cell: cell(3, 1) },
+    { id: 'Sheet', cell: cell(4, 1) },
+    { id: 'Swiper', cell: cell(1, 2) },
+    { id: 'Dialog', cell: cell(4, 2) },
+    { id: 'Popover', cell: cell(3, 2) },
+    { id: 'MoonRise', cell: cell(2, 2) },
+  ],
+} satisfies Record<StudioViewMode, ModeLayoutItem[]>;
+
+function getModeItemId(item: ModeLayoutItem): StageId {
+  return typeof item === 'string' ? item : item.id;
+}
+
+function getModeItemCell(
+  item: ModeLayoutItem,
+  index: number,
+): Cell {
+  if (typeof item === 'string') {
+    return cell(index + 1, 1);
+  }
+  return item.cell;
+}
+
+function toGridStyle(cellValue: Cell): CSSProperties {
+  const colEnd = cellValue.col + (cellValue.colSpan ?? 1);
+  const rowEnd = cellValue.row + (cellValue.rowSpan ?? 1);
+
+  return {
+    gridColumnStart: cellValue.col,
+    gridColumnEnd: colEnd,
+    gridRowStart: cellValue.row,
+    gridRowEnd: rowEnd,
+  };
+}
+
+function resolveModeLayout(mode: StudioViewMode): StageEntry[] {
+  return modeLayout[mode].map((item, index) => {
+    const id = getModeItemId(item);
+    const stage: StageCatalogItem = stageCatalog[id];
+    const stageCell = getModeItemCell(item, index);
+
+    return {
+      id,
+      style: toGridStyle(stageCell),
+      entry: stage.entry,
+      theme: stage.theme,
+      ...(stage.studio?.component !== undefined
+        ? { componentId: stage.studio.component.key }
+        : {}),
+      ...(stage.studio?.component?.meta !== undefined
+        ? { meta: stage.studio.component.meta }
+        : {}),
+    };
+  });
+}
+
+/** Draft grid-first layout data kept next to the current Tailwind-string version for comparison. */
+const studioLayoutGridDraft: StudioLayout = {
+  compare: resolveModeLayout('compare'),
+  focus: resolveModeLayout('focus'),
+  lineup: resolveModeLayout('lineup'),
+};
+
+export type { Cell, GridSpec, ModeLayoutItem, StageCatalogItem, StageId };
+export { modeGrid, modeLayout, stageCatalog, studioLayoutGridDraft };

--- a/apps/studio/src/components/studio/studio-layout.ts
+++ b/apps/studio/src/components/studio/studio-layout.ts
@@ -10,12 +10,19 @@ import { LynxUIComponentsRegistry } from '../../constants';
 
 const getMeta = LynxUIComponentsRegistry.getMeta;
 
+/** Legacy layout snapshot kept only for side-by-side comparison with the new data-driven grid config. */
+
 /** App-local stage catalog that keeps demo-specific entry and registry metadata out of choreography core. */
 type StudioStageDefinition = {
   entry: string;
   theme: LunaThemeKey;
   componentId?: string;
 } & Record<string, unknown>;
+
+type LegacyLayoutItem = {
+  id: string;
+  className: string;
+};
 
 const stageCatalog: Record<string, StudioStageDefinition> = {
   Bloom: { entry: 'ActBloom', theme: 'lunaris-light' },
@@ -189,10 +196,10 @@ const baseLayout = {
       className: 'col-start-2 col-end-3 row-start-2 row-end-3 order-3',
     },
   ],
-} satisfies Record<StudioViewMode, Pick<StageEntry, 'className' | 'id'>[]>;
+} satisfies Record<StudioViewMode, LegacyLayoutItem[]>;
 
 function mapStageEntries(
-  entries: Pick<StageEntry, 'className' | 'id'>[],
+  entries: LegacyLayoutItem[],
 ): StageEntry[] {
   return entries.map((entry) => {
     const stage = stageCatalog[entry.id];
@@ -202,14 +209,13 @@ function mapStageEntries(
 
     const stageEntry: StageEntry = {
       id: entry.id,
-      className: entry.className,
       ...stage,
     };
     return stageEntry;
   });
 }
 
-/** Demo layout consumed by the app-local Studio shell and passed into generic choreography core. */
+/** Legacy demo layout kept for reference only; the active Studio shell now uses `studio-layout-grid.ts`. */
 const studioLayout: StudioLayout = {
   compare: mapStageEntries(baseLayout.compare),
   focus: mapStageEntries(baseLayout.focus),

--- a/apps/studio/src/components/studio/studio.tsx
+++ b/apps/studio/src/components/studio/studio.tsx
@@ -17,7 +17,7 @@ import type {
 } from '@/types';
 import { cn } from '@/utils';
 
-import { studioLayout } from './studio-layout';
+import { modeGrid, studioLayoutGridDraft } from './studio-layout-grid';
 import { useThemeKeyboardControls } from './use-theme-keyboard-controls';
 
 const viewModes: StudioViewMode[] = ['compare', 'focus', 'lineup'];
@@ -71,7 +71,9 @@ function Studio({ className }: { className?: string }) {
       )}
     >
       <Choreography
-        layout={studioLayout}
+        layout={studioLayoutGridDraft}
+        className='gap-4'
+        modeGrid={modeGrid}
         viewMode={viewMode}
         interactionTarget={'lynx'}
         onLynxRuntimeCall={handleLynxRuntimeCall}

--- a/packages/luna-studio/package.json
+++ b/packages/luna-studio/package.json
@@ -41,9 +41,7 @@
   },
   "dependencies": {
     "@dugyu/luna-core": "workspace:*",
-    "@dugyu/luna-stage": "workspace:*",
-    "clsx": "catalog:utils",
-    "tailwind-merge": "catalog:tailwind"
+    "@dugyu/luna-stage": "workspace:*"
   },
   "devDependencies": {
     "@rsbuild/plugin-react": "catalog:rsbuild",

--- a/packages/luna-studio/src/choreography/choreography.tsx
+++ b/packages/luna-studio/src/choreography/choreography.tsx
@@ -3,24 +3,30 @@
 // LICENSE file in the root directory of this source tree.
 
 import { LayoutGroup } from 'motion/react';
-import type { JSX } from 'react';
+import type { CSSProperties, JSX } from 'react';
 
 import type { LynxRuntimeCall } from '../lynx-stage';
 import type {
   LunaThemeMode,
   LunaThemeVariant,
   StudioLayout,
+  StudioModeGrid,
   StudioViewMode,
 } from '../types';
 import { DynamicView } from './dynamic-view';
 import type { StageEvent } from './types';
 
 type ChoreographyProps = {
+  /** Optional class name applied to the outer choreography container. */
+  className?: string;
+  /** Optional inline style merged onto the outer choreography container. */
+  style?: CSSProperties;
   /** Fully resolved stage layout used by the choreography layer. */
   layout: StudioLayout;
+  /** Optional grid config that drives the container layout for each mode. */
+  modeGrid?: StudioModeGrid;
   /** Active presentation mode for the current choreography render. */
   viewMode: StudioViewMode;
-  className?: string;
   /** Chooses whether pointer interaction is handled by Lynx content or the outer Web container. */
   interactionTarget?: 'lynx' | 'container';
   /** Receives generic runtime calls emitted from the embedded Lynx content. */
@@ -35,11 +41,13 @@ type ChoreographyProps = {
 
 function Choreography({
   layout,
+  modeGrid,
   viewMode = 'compare',
   themeVariant = 'lunaris',
   themeMode = 'dark',
   interactionTarget = 'lynx',
   className,
+  style,
   onLynxRuntimeCall,
   onStageEvent,
 }: ChoreographyProps): JSX.Element {
@@ -47,12 +55,14 @@ function Choreography({
     <LayoutGroup id='luna-studio'>
       <DynamicView
         layout={layout}
+        {...(modeGrid !== undefined ? { modeGrid } : {})}
         mode={viewMode}
         key='luna-studio-dynamic-view'
         themeVariant={themeVariant}
         themeMode={themeMode}
         interactionTarget={interactionTarget}
         {...(className !== undefined ? { className } : {})}
+        {...(style !== undefined ? { style } : {})}
         {...(onLynxRuntimeCall !== undefined ? { onLynxRuntimeCall } : {})}
         {...(onStageEvent !== undefined ? { onStageEvent } : {})}
       />

--- a/packages/luna-studio/src/choreography/dynamic-view.tsx
+++ b/packages/luna-studio/src/choreography/dynamic-view.tsx
@@ -2,16 +2,15 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import { clsx } from 'clsx';
 import { AnimatePresence } from 'motion/react';
 import type { SpringOptions, Transition } from 'motion/react';
 import type {
+  CSSProperties,
   JSX,
   MouseEvent as ReactMouseEvent,
   PointerEvent as ReactPointerEvent,
 } from 'react';
 import { useMemo, useState } from 'react';
-import { twMerge } from 'tailwind-merge';
 
 import {
   MotionPresentation,
@@ -26,6 +25,7 @@ import type {
   LunaThemeVariant,
   StageEntry,
   StudioLayout,
+  StudioModeGrid,
   StudioViewMode,
 } from '../types';
 import type { StageEvent } from './types';
@@ -56,10 +56,12 @@ const presentationTransition: Transition = {
 const fitTransition: SpringOptions = { visualDuration: 0.8, bounce: 0.1 };
 
 const DEFAULT_FOCUSED = 'button';
-
-function cn(...inputs: (string | false | null | undefined)[]) {
-  return twMerge(clsx(inputs));
-}
+const BASE_STYLE: CSSProperties = {
+  width: '100%',
+  height: '100%',
+  pointerEvents: 'none',
+  position: 'relative',
+};
 
 function hasComponentId(stage: StageEntry): stage is FocusableStageEntry {
   return Boolean(stage.componentId);
@@ -68,9 +70,14 @@ function hasComponentId(stage: StageEntry): stage is FocusableStageEntry {
 type DynamicViewProps = {
   /** Stage layout data for all supported studio view modes. */
   layout: StudioLayout;
+  /** Optional grid config that drives the container layout for each mode. */
+  modeGrid?: StudioModeGrid;
   /** Active mode selecting which layout slice to render. */
   mode?: StudioViewMode;
+  /** Optional class name applied to the outer choreography container. */
   className?: string;
+  /** Optional inline style merged onto the outer choreography container. */
+  style?: CSSProperties;
   /** Resolved theme variant passed down to rendered Lynx stages. */
   themeVariant?: LunaThemeVariant;
   /** Resolved theme mode passed down to rendered Lynx stages. */
@@ -85,8 +92,10 @@ type DynamicViewProps = {
 
 function DynamicView({
   layout,
+  modeGrid,
   mode = 'compare',
   className,
+  style,
   themeVariant = 'lunaris',
   themeMode = 'dark',
   interactionTarget = 'lynx',
@@ -95,6 +104,8 @@ function DynamicView({
 }: DynamicViewProps): JSX.Element {
   const [focused, setFocused] = useState<string>(DEFAULT_FOCUSED);
   const containerInteractive = interactionTarget === 'container';
+
+  const containerGrid = modeGrid?.[mode];
 
   const handleLynxRuntimeCall = useMemo(() => {
     return (call: LynxRuntimeCall) => {
@@ -171,17 +182,38 @@ function DynamicView({
     });
   }, [focused, layout, mode]);
 
+  const containerStyle: CSSProperties | undefined = useMemo(() => {
+    const baseGridStyle = containerGrid === undefined ? {} : {
+      display: 'grid',
+      gridTemplateColumns: `repeat(${containerGrid.cols}, minmax(0, 1fr))`,
+      gridTemplateRows: `repeat(${containerGrid.rows}, minmax(0, 1fr))`,
+      alignItems: 'stretch',
+    };
+    return {
+      ...BASE_STYLE,
+      ...baseGridStyle,
+    };
+  }, [containerGrid]);
+
+  const mergedContainerStyle: CSSProperties = useMemo(() => {
+    return {
+      ...containerStyle,
+      ...style,
+    };
+  }, [containerStyle, style]);
+
+  const stageOutlineStyle: CSSProperties = useMemo(() => {
+    return {
+      backgroundColor: themeMode === 'light'
+        ? 'rgb(0 0 0 / 0.04)'
+        : 'rgb(255 255 255 / 0.05)',
+    };
+  }, [themeMode]);
+
   return (
     <div
-      className={cn(
-        'size-full gap-4 pointer-events-none relative',
-        // Compare mode must stretch cross-axis height; centering would let each
-        // stage item shrink to the container-motion anchor's intrinsic 4px height.
-        mode === 'compare' && 'flex flex-row items-stretch justify-between',
-        mode === 'focus' && 'grid grid-cols-3 grid-rows-1',
-        mode === 'lineup' && 'grid grid-cols-5 grid-rows-2',
-        className,
-      )}
+      className={className}
+      style={mergedContainerStyle}
     >
       <AnimatePresence mode='popLayout'>
         {rendered.map((stage) => {
@@ -192,6 +224,7 @@ function DynamicView({
               className={stage.className}
               {...getStageContainerEventHandlers(stage)}
               style={{
+                ...stage.style,
                 zIndex: stage.zIndex,
                 pointerEvents: containerInteractive ? 'auto' : 'none',
               }}
@@ -209,9 +242,7 @@ function DynamicView({
                   fitTransition={fitTransition}
                   world={stage.world}
                   focalLength={mode === 'focus' ? 500 : 0}
-                  className={themeMode === 'light'
-                    ? 'bg-black opacity-[0.04]'
-                    : 'bg-white opacity-5'}
+                  style={stageOutlineStyle}
                   contentInteractive={interactionTarget === 'lynx'}
                   maskColor={themeMode === 'light' ? '#f5f5f5' : '#00000080'}
                   maskOpacity={stage.maskOpacity}

--- a/packages/luna-studio/src/types/index.ts
+++ b/packages/luna-studio/src/types/index.ts
@@ -2,6 +2,8 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import type { CSSProperties } from 'react';
+
 import type {
   LunaThemeKey,
   LunaThemeMode,
@@ -12,11 +14,18 @@ export type { LunaThemeKey, LunaThemeMode, LunaThemeVariant };
 
 export type StudioViewMode = 'compare' | 'focus' | 'lineup';
 
+export type StudioGridSpec = {
+  cols: number;
+  rows: number;
+};
+
 export type StageEntry = {
   /** Stable stage identifier used for layout and event correlation. */
   id: string;
-  /** Additional layout className applied to the stage container. */
-  className: string;
+  /** Optional layout className applied to the stage container. */
+  className?: string;
+  /** Optional inline layout style applied to the stage container. */
+  style?: CSSProperties;
   /** Lynx bundle entry rendered in this stage. */
   entry: string;
   /** Theme key applied to this stage when rendered in compare mode. */
@@ -27,3 +36,6 @@ export type StageEntry = {
 
 /** Layout data for the three built-in studio presentation modes. */
 export type StudioLayout = Record<StudioViewMode, StageEntry[]>;
+
+/** Optional mode-to-grid mapping used by grid-driven choreography containers. */
+export type StudioModeGrid = Record<StudioViewMode, StudioGridSpec>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,30 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 catalogs:
-  lynx:
-    '@lynx-js/react':
-      specifier: 0.114.4
-      version: 0.114.4
-    '@lynx-js/web-core':
-      specifier: 0.20.2
-      version: 0.20.2
-  lynx-build:
-    '@lynx-js/qrcode-rsbuild-plugin':
-      specifier: 0.4.6
-      version: 0.4.6
-    '@lynx-js/react-rsbuild-plugin':
-      specifier: 0.15.0
-      version: 0.15.0
-    '@lynx-js/rspeedy':
-      specifier: 0.14.1
-      version: 0.14.1
-  lynx-dev:
-    '@lynx-js/preact-devtools':
-      specifier: 5.0.1-cf9aef5
-      version: 5.0.1-cf9aef5
-    '@lynx-js/types':
-      specifier: 3.4.11
-      version: 3.4.11
   motion:
     motion:
       specifier: 12.38.0
@@ -37,9 +13,6 @@ catalogs:
     '@types/react':
       specifier: 18.3.24
       version: 18.3.24
-    '@types/react-dom':
-      specifier: 18.3.7
-      version: 18.3.7
     react:
       specifier: 18.3.1
       version: 18.3.1
@@ -47,59 +20,17 @@ catalogs:
       specifier: 18.3.1
       version: 18.3.1
   rsbuild:
-    '@rsbuild/core':
-      specifier: 1.7.5
-      version: 1.7.5
     '@rsbuild/plugin-react':
       specifier: 1.4.6
       version: 1.4.6
-    '@rsbuild/plugin-type-check':
-      specifier: 1.3.4
-      version: 1.3.4
   rslib:
     '@rslib/core':
       specifier: 0.21.1
       version: 0.21.1
-  tailwind:
-    '@lynx-js/tailwind-preset':
-      specifier: 0.4.0
-      version: 0.4.0
-    rsbuild-plugin-tailwindcss:
-      specifier: 0.2.3
-      version: 0.2.3
-    tailwind-merge:
-      specifier: 2.6.0
-      version: 2.6.0
-    tailwindcss:
-      specifier: 3.4.17
-      version: 3.4.17
-  test:
-    '@testing-library/jest-dom':
-      specifier: 6.9.1
-      version: 6.9.1
-    '@testing-library/react':
-      specifier: 16.3.2
-      version: 16.3.2
-    jsdom:
-      specifier: 29.0.2
-      version: 29.0.2
-    vitest:
-      specifier: 4.1.5
-      version: 4.1.5
   ts:
-    '@types/node':
-      specifier: 24.6.1
-      version: 24.6.1
-    '@typescript/native-preview':
-      specifier: 7.0.0-dev.20251103.1
-      version: 7.0.0-dev.20251103.1
     typescript:
       specifier: 5.9.2
       version: 5.9.2
-  utils:
-    clsx:
-      specifier: 2.1.1
-      version: 2.1.1
 
 importers:
 
@@ -393,19 +324,13 @@ importers:
       '@dugyu/luna-stage':
         specifier: workspace:*
         version: link:../luna-stage
-      clsx:
-        specifier: catalog:utils
-        version: 2.1.1
-      tailwind-merge:
-        specifier: catalog:tailwind
-        version: 2.6.0
     devDependencies:
       '@rsbuild/plugin-react':
         specifier: catalog:rsbuild
         version: 1.4.6(@rsbuild/core@2.0.0-rc.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(core-js@3.47.0))
       '@rslib/core':
         specifier: catalog:rslib
-        version: 0.21.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20251103.1)(core-js@3.47.0)(typescript@5.9.2)
+        version: 0.21.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(core-js@3.47.0)(typescript@5.9.2)
       '@types/react':
         specifier: catalog:react18
         version: 18.3.24
@@ -9948,6 +9873,19 @@ snapshots:
       - '@typescript/native-preview'
       - core-js
 
+  '@rslib/core@0.21.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(core-js@3.47.0)(typescript@5.9.2)':
+    dependencies:
+      '@rsbuild/core': 2.0.0-rc.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(core-js@3.47.0)
+      rsbuild-plugin-dts: 0.21.1(@rsbuild/core@2.0.0-rc.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(core-js@3.47.0))(typescript@5.9.2)
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@module-federation/runtime-tools'
+      - '@typescript/native-preview'
+      - core-js
+
   '@rspack/binding-darwin-arm64@1.7.11':
     optional: true
 
@@ -14099,6 +14037,13 @@ snapshots:
       '@rsbuild/core': 2.0.0-rc.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(core-js@3.47.0)
     optionalDependencies:
       '@typescript/native-preview': 7.0.0-dev.20251103.1
+      typescript: 5.9.2
+
+  rsbuild-plugin-dts@0.21.1(@rsbuild/core@2.0.0-rc.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(core-js@3.47.0))(typescript@5.9.2):
+    dependencies:
+      '@ast-grep/napi': 0.37.0
+      '@rsbuild/core': 2.0.0-rc.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(core-js@3.47.0)
+    optionalDependencies:
       typescript: 5.9.2
 
   rsbuild-plugin-tailwindcss@0.2.3(@rsbuild/core@1.7.5)(tailwindcss@3.4.17):


### PR DESCRIPTION
Convert choreography layout styling to a data-driven model. Remove tailwind-merge and clsx.

- add modeGrid-driven container layout
- move stage placement to structured cell/style data
- make compare mode use explicit grid placement without DOM reordering
- replace local Tailwind utility composition in DynamicView with style objects
- remove clsx and tailwind-merge from this styling path

Keep the legacy layout file for reference only.
Leave focus key migration to a follow-up change.

## Related

- Implementing #103 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Grid-based layout system for studio stages supporting multiple view modes (compare, focus, lineup) with configurable grid dimensions and per-mode stage positioning

* **Refactor**
  * Choreography component styling architecture updated to use CSS grid layout with inline style properties, replacing utility-class-based approach

* **Chores**
  * Removed unused styling library dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->