### PR TITLE
chore: release luna-studio, luna-stage and luna-demo-bundles

### DIFF
--- a/.changeset/silly-mangos-shake.md
+++ b/.changeset/silly-mangos-shake.md
@@ -1,0 +1,7 @@
+---
+"@dugyu/luna-demo-bundles": minor
+"@dugyu/luna-studio": minor
+"@dugyu/luna-stage": minor
+---
+
+Initial release.

--- a/packages/luna-demo-bundles/package.json
+++ b/packages/luna-demo-bundles/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dugyu/luna-demo-bundles",
   "version": "0.0.0",
-  "private": true,
   "description": "Prebuilt Lynx web bundle assets used by the luna stage/studio minimal demo",
   "keywords": [
     "luna",
@@ -29,5 +28,8 @@
   ],
   "scripts": {
     "build": "node ./build.mjs"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/luna-stage/package.json
+++ b/packages/luna-stage/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dugyu/luna-stage",
   "version": "0.0.0",
-  "private": true,
   "description": "Stage system and showcase components for the L.U.N.A project",
   "keywords": [
     "luna",
@@ -78,5 +77,8 @@
     "motion": {
       "optional": true
     }
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/luna-studio/package.json
+++ b/packages/luna-studio/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dugyu/luna-studio",
   "version": "0.0.0",
-  "private": true,
   "description": "Stage system and showcase components for the L.U.N.A project",
   "keywords": [
     "luna",
@@ -58,5 +57,8 @@
     "motion": ">=12.23.16",
     "react": ">=18.0.0",
     "react-dom": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
- initial release of luna-studio, luna-stage, luna-demo-bundles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Three core packages (luna-demo-bundles, luna-studio, and luna-stage) are now publicly available for community use and integration.
  * Minor version updates released to mark the initial public availability milestone.
  * All packages are configured and ready for public download, distribution, and seamless project integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->