### PR TITLE
fix: drop react-dom peer deps for luna-stage/luna-studio

### DIFF
--- a/.changeset/calm-owls-protect.md
+++ b/.changeset/calm-owls-protect.md
@@ -1,0 +1,6 @@
+---
+"@dugyu/luna-stage": patch
+"@dugyu/luna-studio": patch
+---
+
+Remove unnecessary react-dom peer dependency and refresh installation docs.

--- a/packages/luna-stage/README.md
+++ b/packages/luna-stage/README.md
@@ -14,7 +14,7 @@ pnpm i @dugyu/luna-stage
 **Peer dependencies** — install in your application:
 
 ```sh
-pnpm i react react-dom
+pnpm i react
 ```
 
 For Lynx rendering (`LynxStage` / `LunaLynxStage`), install the Lynx Web runtime:

--- a/packages/luna-stage/package.json
+++ b/packages/luna-stage/package.json
@@ -67,8 +67,7 @@
   "peerDependencies": {
     "@lynx-js/web-core": ">=0.20.0",
     "motion": ">=12.23.16",
-    "react": ">=18.0.0",
-    "react-dom": ">=18.0.0"
+    "react": ">=18.0.0"
   },
   "peerDependenciesMeta": {
     "@lynx-js/web-core": {

--- a/packages/luna-studio/README.md
+++ b/packages/luna-studio/README.md
@@ -26,7 +26,7 @@ If you only need a single device-framed preview, use [`@dugyu/luna-stage`](../lu
 ## Installation
 
 ```sh
-npm i @dugyu/luna-studio @lynx-js/web-core motion react react-dom
+npm i @dugyu/luna-studio @lynx-js/web-core motion react
 ```
 
 `luna-studio` depends on `@dugyu/luna-stage` internally for its rendering primitives and expects the Lynx Web runtime to be available through `@lynx-js/web-core`.

--- a/packages/luna-studio/package.json
+++ b/packages/luna-studio/package.json
@@ -55,8 +55,7 @@
   "peerDependencies": {
     "@lynx-js/web-core": ">=0.20.0",
     "motion": ">=12.23.16",
-    "react": ">=18.0.0",
-    "react-dom": ">=18.0.0"
+    "react": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -336,6 +336,8 @@ importers:
         specifier: catalog:ts
         version: 5.9.2
 
+  packages/luna-demo-bundles: {}
+
   packages/luna-stage:
     dependencies:
       '@dugyu/luna-core':


### PR DESCRIPTION
- Remove unnecessary `react-dom` from peerDependencies (runtime code does not import it; usage is limited to tests)
- Update installation docs accordingly
- Add a patch changeset covering the peer dependency adjustment
- Commit the lockfile update from the local install normalization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unnecessary `react-dom` peer dependency from luna-stage and luna-studio. Now only `react` (>=18.0.0) is required.

* **Documentation**
  * Updated installation documentation to reflect simplified peer dependency requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->