### PR TITLE
fix(lynx-stage): set lynx-view url via attribute to avoid init race

### DIFF
--- a/.changeset/lynx-stage-url-attribute.md
+++ b/.changeset/lynx-stage-url-attribute.md
@@ -1,0 +1,5 @@
+---
+"@dugyu/luna-stage": patch
+---
+
+Fix `<lynx-view>` initialization race by setting `url` via JSX attribute and mounting only after the Lynx runtime is ready. Expose `src` and `ready` from `useLynxStage` to support this flow.

--- a/.cspell/misc.txt
+++ b/.cspell/misc.txt
@@ -1,4 +1,5 @@
 avenir
+dlog
 elif
 esac
 instantiator
@@ -6,12 +7,12 @@ lerp
 manypkg
 npmjs
 pipefail
+pointercancel
+pointerdown
+pointerup
 qrcode
 realpath
 startswith
 svitejs
 tostring
 tsgo
-pointerdown
-pointerup
-pointercancel

--- a/packages/luna-stage/examples/basic/src/demos/vanilla-lynx/index.tsx
+++ b/packages/luna-stage/examples/basic/src/demos/vanilla-lynx/index.tsx
@@ -1,0 +1,42 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import '@lynx-js/web-core/client';
+
+import { useState } from 'react';
+
+function TestAttr() {
+  return (
+    <lynx-view
+      url='/SwitchBasic.web.bundle'
+      style={{ width: 375, height: 812, display: 'block' }}
+    />
+  );
+}
+
+function TestProp() {
+  return (
+    <lynx-view
+      ref={(el) => {
+        if (el) {
+          // @ts-expect-error custom element type
+          el.url = '/SwitchBasic.web.bundle';
+        }
+      }}
+      style={{ width: 375, height: 812, display: 'block' }}
+    />
+  );
+}
+
+export default function Demo() {
+  const [mode, setMode] = useState<'attr' | 'prop'>('attr');
+  return (
+    <>
+      <button onClick={() => setMode(m => m === 'attr' ? 'prop' : 'attr')}>
+        {mode}
+      </button>
+      {mode === 'attr' ? <TestAttr /> : <TestProp />}
+    </>
+  );
+}

--- a/packages/luna-stage/src/lynx/__tests__/lynx-stage-hydration.test.tsx
+++ b/packages/luna-stage/src/lynx/__tests__/lynx-stage-hydration.test.tsx
@@ -15,9 +15,17 @@ import { LunaLynxStage } from '../luna-lynx-stage';
 import { LynxStage } from '../lynx-stage';
 
 // Mock the web-core runtime to avoid actual loading and network requests in tests
-vi.mock('@lynx-js/web-core/client', () => ({
-  default: {},
-}));
+vi.mock('@lynx-js/web-core/client', () => {
+  if (
+    typeof customElements !== 'undefined' && !customElements.get('lynx-view')
+  ) {
+    customElements.define(
+      'lynx-view',
+      class LynxViewMock extends HTMLElement {},
+    );
+  }
+  return { default: {} };
+});
 
 describe('LynxStage Client Mounting Behavior', () => {
   it('should mount correctly on the client side after useIsClient resolves', async () => {

--- a/packages/luna-stage/src/lynx/luna-lynx-stage.tsx
+++ b/packages/luna-stage/src/lynx/luna-lynx-stage.tsx
@@ -10,7 +10,8 @@ import type { LunaThemeKey, LunaThemeVariant } from '@dugyu/luna-core';
 import {
   CONTAINER_STYLE,
   DEFAULT_GROUP_ID,
-  LYNX_VIEW_STYLE,
+  LYNX_VIEW_STYLE_INTERACTIVE,
+  LYNX_VIEW_STYLE_NON_INTERACTIVE,
 } from './lynx-stage-constants';
 import type { UseLynxStageOptions } from './types';
 import { useLynxStage } from './use-lynx-stage';
@@ -64,7 +65,7 @@ function LunaLynxStageImpl({
     };
   }, [extraGlobalProps, lunaTheme]);
 
-  const { lynxViewRef, containerRef } = useLynxStage({
+  const { lynxViewRef, containerRef, src, ready } = useLynxStage({
     ...stageOptions,
     globalProps,
     bundleRoot,
@@ -72,16 +73,19 @@ function LunaLynxStageImpl({
 
   return (
     <div ref={containerRef} style={CONTAINER_STYLE}>
-      <lynx-view
-        ref={lynxViewRef}
-        style={{
-          ...LYNX_VIEW_STYLE,
-          pointerEvents: interactive ? 'auto' : 'none',
-        }}
-        lynx-group-id={groupId}
-        transform-vh={true}
-        transform-vw={true}
-      />
+      {ready && (
+        <lynx-view
+          key={src}
+          ref={lynxViewRef}
+          url={src}
+          style={interactive
+            ? LYNX_VIEW_STYLE_INTERACTIVE
+            : LYNX_VIEW_STYLE_NON_INTERACTIVE}
+          lynx-group-id={groupId}
+          transform-vh={true}
+          transform-vw={true}
+        />
+      )}
     </div>
   );
 }

--- a/packages/luna-stage/src/lynx/lynx-stage-constants.ts
+++ b/packages/luna-stage/src/lynx/lynx-stage-constants.ts
@@ -22,6 +22,17 @@ export const LYNX_VIEW_STYLE: CSSProperties & CSSVarProperties = {
   '--vw-unit': '1cqw',
 };
 
+export const LYNX_VIEW_STYLE_INTERACTIVE: CSSProperties & CSSVarProperties = {
+  ...LYNX_VIEW_STYLE,
+  pointerEvents: 'auto',
+};
+
+export const LYNX_VIEW_STYLE_NON_INTERACTIVE: CSSProperties & CSSVarProperties =
+  {
+    ...LYNX_VIEW_STYLE,
+    pointerEvents: 'none',
+  };
+
 export const CONTAINER_STYLE: CSSProperties = {
   position: 'relative',
   width: '100%',

--- a/packages/luna-stage/src/lynx/lynx-stage.tsx
+++ b/packages/luna-stage/src/lynx/lynx-stage.tsx
@@ -7,7 +7,8 @@ import type { ReactNode } from 'react';
 import {
   CONTAINER_STYLE,
   DEFAULT_GROUP_ID,
-  LYNX_VIEW_STYLE,
+  LYNX_VIEW_STYLE_INTERACTIVE,
+  LYNX_VIEW_STYLE_NON_INTERACTIVE,
 } from './lynx-stage-constants';
 import type { UseLynxStageOptions } from './types';
 import { useLynxStage } from './use-lynx-stage';
@@ -41,23 +42,26 @@ function LynxStageImpl({
   interactive = true,
   ...stageOptions
 }: LynxStageProps): ReactNode {
-  const { lynxViewRef, containerRef } = useLynxStage({
+  const { lynxViewRef, containerRef, src, ready } = useLynxStage({
     bundleRoot: bundleRoot ?? '/',
     ...stageOptions,
   });
 
   return (
     <div ref={containerRef} style={CONTAINER_STYLE}>
-      <lynx-view
-        ref={lynxViewRef}
-        style={{
-          ...LYNX_VIEW_STYLE,
-          pointerEvents: interactive ? 'auto' : 'none',
-        }}
-        lynx-group-id={groupId}
-        transform-vh={true}
-        transform-vw={true}
-      />
+      {ready && (
+        <lynx-view
+          key={src}
+          ref={lynxViewRef}
+          url={src}
+          style={interactive
+            ? LYNX_VIEW_STYLE_INTERACTIVE
+            : LYNX_VIEW_STYLE_NON_INTERACTIVE}
+          lynx-group-id={groupId}
+          transform-vh={true}
+          transform-vw={true}
+        />
+      )}
     </div>
   );
 }

--- a/packages/luna-stage/src/lynx/types.ts
+++ b/packages/luna-stage/src/lynx/types.ts
@@ -73,4 +73,15 @@ export type UseLynxStageResult = {
   lynxViewRef: RefObject<LynxView>;
   /** Attach to the container `<div>` wrapping `<lynx-view>`. */
   containerRef: RefObject<HTMLDivElement>;
+  /**
+   * Resolved bundle URL for the current `entry`/`bundleRoot`.
+   * Pass this value to `<lynx-view url={src} />` so the URL is available
+   * at element creation time (avoids ref/effect timing races).
+   */
+  src: string;
+  /**
+   * Whether the Lynx runtime (`@lynx-js/web-core/client`) has finished loading.
+   * When `false`, delay mounting `<lynx-view>` to avoid upgrade/handshake races.
+   */
+  ready: boolean;
 };

--- a/packages/luna-stage/src/lynx/use-lynx-stage.ts
+++ b/packages/luna-stage/src/lynx/use-lynx-stage.ts
@@ -3,10 +3,9 @@
 // LICENSE file in the root directory of this source tree.
 
 import type { LynxViewElement as LynxView } from '@lynx-js/web-core/client';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import type { UseLynxStageOptions, UseLynxStageResult } from './types';
-import { useContainerResize } from '../hooks/use-container-resize';
 import { useEventCallback } from '../hooks/use-event-callback';
 import '../types/lynx-view';
 
@@ -32,19 +31,37 @@ function normalizeBundleRoot(bundleRoot: string): string {
     : `${bundleRoot}/`;
 }
 
+// ─── Debug logger ─────────────────────────────────────────────────────────────
+
+const DEBUG = false;
+const t0 = typeof performance !== 'undefined' ? performance.now() : 0;
+function dlog(tag: string, ...args: unknown[]): void {
+  if (!DEBUG) return;
+  const elapsed = (performance.now() - t0).toFixed(0).padStart(6);
+  console.log(`[lynx +${elapsed}ms] ${tag}`, ...args);
+}
+
 // ─── Runtime singleton ────────────────────────────────────────────────────────
 
 let runtimeReady: Promise<void> | null = null;
 
 function ensureRuntime(): Promise<void> {
-  return (runtimeReady ??= import('@lynx-js/web-core/client')
-    .then(() => {
-      /* side-effect only: registers <lynx-view> custom element */
-    })
-    .catch((error) => {
-      runtimeReady = null;
-      throw error;
-    }));
+  return (runtimeReady ??= (() => {
+    dlog('runtime:import:start');
+    return import('@lynx-js/web-core/client')
+      .then(() => {
+        dlog('runtime:import:done');
+        // Verify customElements is registered
+        const defined = typeof customElements !== 'undefined'
+          && customElements.get('lynx-view');
+        dlog('runtime:custom-element-defined', !!defined);
+      })
+      .catch((error) => {
+        dlog('runtime:import:error', error);
+        runtimeReady = null;
+        throw error;
+      });
+  })());
 }
 
 export function useLynxStage({
@@ -60,187 +77,93 @@ export function useLynxStage({
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   const [ready, setReady] = useState(false);
-  const [dimsReady, setDimsReady] = useState(false);
 
   const renderedRef = useRef(false);
-  const browserConfigInitializedRef = useRef(false);
-  const lastUrlRef = useRef<string>('');
-  const containerSizeRef = useRef({ width: 0, height: 0 });
-  const dimsReadyRef = useRef(false);
 
   // Stable refs for callbacks — avoids re-running effects on every render
   const reportReadyEvent = useEventCallback(onReady);
   const reportErrorEvent = useEventCallback(onError);
   const onNativeModulesCallEvent = useEventCallback(onNativeModulesCall);
-  const resolveBundleSrcEvent = useEventCallback(resolveBundleSrc);
 
-  // Reset on entry / bundle root change
+  const normalizedBundleRoot = normalizeBundleRoot(bundleRoot);
+  const src = resolveBundleSrc?.({
+    bundleRoot: normalizedBundleRoot,
+    entry,
+  }) ?? `${normalizedBundleRoot}${entry}.web.bundle`;
+
+  // Reset when the resolved bundle URL changes.
   useEffect(() => {
+    dlog(`reset(${entry})`);
     renderedRef.current = false;
-    browserConfigInitializedRef.current = false;
-    lastUrlRef.current = '';
-  }, [entry, bundleRoot]);
+  }, [src, entry]);
 
   // Load web-core eagerly on mount
   useEffect(() => {
+    dlog(`runtime-effect(${entry}):start`);
     ensureRuntime()
-      .then(() => setReady(true))
+      .then(() => {
+        dlog(`runtime-effect(${entry}):resolved → setReady(true)`);
+        setReady(true);
+      })
       .catch((err: unknown) => {
+        dlog(`runtime-effect(${entry}):rejected`, err);
         reportErrorEvent(
           `Failed to load Lynx runtime: ${
             err instanceof Error ? err.message : String(err)
           }`,
         );
       });
-  }, [reportErrorEvent]);
+  }, [reportErrorEvent, entry]);
 
-  // Watch container dimensions — gate URL assignment on non-zero size
-  useContainerResize({
-    ref: containerRef,
-    onResize: ({ width, height }) => {
-      const w = width ?? 0;
-      const h = height ?? 0;
-      containerSizeRef.current = { width: w, height: h };
-      const valid = w > 0 && h > 0;
-      if (valid !== dimsReadyRef.current) {
-        dimsReadyRef.current = valid;
-        setDimsReady(valid);
-      }
-    },
-  });
-
-  // Set browserConfig from container size.
-  // Can only be set once — must have valid dimensions.
-  const setDimensions = useCallback((): boolean => {
-    if (!lynxViewRef.current) return false;
-    if (browserConfigInitializedRef.current) return true;
-    const { width, height } = containerSizeRef.current;
-    if (width === 0 || height === 0) return false;
-    const pixelRatio = window.devicePixelRatio;
-    lynxViewRef.current.browserConfig = {
-      pixelWidth: Math.round(width * pixelRatio),
-      pixelHeight: Math.round(height * pixelRatio),
-      pixelRatio,
-    };
-    browserConfigInitializedRef.current = true;
-    return true;
-  }, []);
-
-  // Wire up onNativeModulesCall after runtime is ready. `useEventCallback`
-  // ensures the proxy always calls the latest handler without re-wiring.
+  // Wire up onNativeModulesCall after runtime is ready
   useEffect(() => {
     const view = lynxViewRef.current as LynxViewWithExtensions | null;
-    if (!view) return;
+    if (!view) {
+      dlog(`nativeModules(${entry}): no view yet`);
+      return;
+    }
+    dlog(`nativeModules(${entry}): wiring`);
     view.onNativeModulesCall = (name, data, moduleName) =>
       onNativeModulesCallEvent(name, data, moduleName);
-  }, [ready, onNativeModulesCallEvent]);
+  }, [ready, onNativeModulesCallEvent, entry]);
 
   // Inject globalProps whenever they change
   useEffect(() => {
-    if (!globalProps || !lynxViewRef.current || !renderedRef.current) return;
+    if (!globalProps || !lynxViewRef.current) return;
+    dlog(`globalProps(${entry}): updating`);
     lynxViewRef.current.updateGlobalProps(
       globalProps as unknown as UpdateGlobalPropsArg,
     );
-  }, [globalProps]);
+  }, [globalProps, entry]);
 
-  // Assign URL once runtime + dimensions are ready
   useEffect(() => {
     const lynxView = lynxViewRef.current as LynxViewWithExtensions | null;
-    if (!ready || !dimsReady || !lynxView) return;
+    if (!ready || !lynxView || renderedRef.current) return;
 
-    const normalizedBundleRoot = normalizeBundleRoot(bundleRoot);
-    const src = resolveBundleSrcEvent({
-      bundleRoot: normalizedBundleRoot,
-      entry,
-    }) ?? `${normalizedBundleRoot}${entry}.web.bundle`;
-    const urlAlreadySet = lastUrlRef.current === src;
-
-    const initialized = setDimensions();
-    if (!initialized) return;
-
-    if (!urlAlreadySet) {
-      lynxView.url = src;
-      lastUrlRef.current = src;
-    }
-
-    // Poll for shadow root, then watch for first child to mark rendered
-    const el = lynxView as unknown as HTMLElement;
-    let disposed = false;
-    let mo: MutationObserver | undefined;
-
-    const markRendered = () => {
+    const t = setTimeout(() => {
       if (renderedRef.current) return;
       renderedRef.current = true;
-      // Flush globalProps that arrived before render was complete
       if (globalProps) {
         lynxView.updateGlobalProps(
           globalProps as unknown as UpdateGlobalPropsArg,
         );
       }
       reportReadyEvent();
-    };
+    }, 0);
 
-    const setupShadow = (shadow: ShadowRoot) => {
-      if (shadow.childElementCount > 0) {
-        markRendered();
-      } else {
-        mo = new MutationObserver(() => {
-          if (shadow.childElementCount > 0) {
-            markRendered();
-            mo!.disconnect();
-          }
-        });
-        mo.observe(shadow, { childList: true, subtree: true });
-      }
-    };
-
-    let timer: ReturnType<typeof setTimeout> | undefined;
-
-    if (!renderedRef.current) {
-      const pollStart = performance.now();
-      const pollShadow = () => {
-        if (disposed) return;
-        if (performance.now() - pollStart > 3000) {
-          if (timer) clearTimeout(timer);
-          reportErrorEvent('Preview timed out: shadow root was not created');
-          return;
-        }
-        const shadow = el.shadowRoot;
-        if (shadow) setupShadow(shadow);
-        else requestAnimationFrame(pollShadow);
-      };
-      pollShadow();
-
-      timer = setTimeout(() => {
-        if (!renderedRef.current) {
-          reportErrorEvent(
-            'Preview timed out: rendering did not complete within 5s',
-          );
-        }
-      }, 5000);
-    } else {
-      // Already rendered — re-attach shadow listener for click fix if needed
-      const shadow = el.shadowRoot;
-      if (shadow) setupShadow(shadow);
-    }
-
-    return () => {
-      disposed = true;
-      if (timer) clearTimeout(timer);
-      mo?.disconnect();
-    };
+    return () => clearTimeout(t);
   }, [
     ready,
-    dimsReady,
     entry,
     bundleRoot,
-    setDimensions,
     globalProps,
-    resolveBundleSrcEvent,
-    onNativeModulesCallEvent,
     reportReadyEvent,
-    reportErrorEvent,
   ]);
 
-  return { lynxViewRef, containerRef };
+  return {
+    lynxViewRef,
+    containerRef,
+    src,
+    ready,
+  };
 }

--- a/packages/luna-stage/src/lynx/use-lynx-stage.ts
+++ b/packages/luna-stage/src/lynx/use-lynx-stage.ts
@@ -49,12 +49,18 @@ function ensureRuntime(): Promise<void> {
   return (runtimeReady ??= (() => {
     dlog('runtime:import:start');
     return import('@lynx-js/web-core/client')
-      .then(() => {
+      .then(async () => {
         dlog('runtime:import:done');
-        // Verify customElements is registered
-        const defined = typeof customElements !== 'undefined'
-          && customElements.get('lynx-view');
-        dlog('runtime:custom-element-defined', !!defined);
+        if (typeof customElements === 'undefined') {
+          return;
+        }
+        if (!customElements.get('lynx-view')) {
+          await customElements.whenDefined('lynx-view');
+        }
+        dlog(
+          'runtime:custom-element-defined',
+          !!customElements.get('lynx-view'),
+        );
       })
       .catch((error) => {
         dlog('runtime:import:error', error);
@@ -140,8 +146,47 @@ export function useLynxStage({
     const lynxView = lynxViewRef.current as LynxViewWithExtensions | null;
     if (!ready || !lynxView || renderedRef.current) return;
 
+    let errored = false;
+    const onError = (event: Event) => {
+      if (errored) return;
+      errored = true;
+      if (!(event instanceof CustomEvent)) {
+        reportErrorEvent('Unknown Lynx error');
+        return;
+      }
+
+      const detail = event.detail as {
+        error?: Error;
+        sourceMap?: { offset?: { line?: number; col?: number } };
+        release?: string;
+        fileName?: 'lepus.js' | 'app-service.js';
+      } | undefined;
+
+      const err = detail?.error;
+      const message = err?.message ?? 'Unknown Lynx error';
+
+      const fileName = detail?.fileName;
+      const release = detail?.release;
+      const line = detail?.sourceMap?.offset?.line;
+      const col = detail?.sourceMap?.offset?.col;
+
+      const location = (line != null || col != null)
+        ? `${line ?? '?'}:${col ?? '?'}`
+        : undefined;
+
+      const context = [
+        fileName,
+        location,
+        release,
+      ].filter(Boolean).join(' ');
+
+      reportErrorEvent(context ? `${message} (${context})` : message);
+    };
+
+    (lynxView as unknown as HTMLElement).addEventListener('error', onError);
+
     const t = setTimeout(() => {
-      if (renderedRef.current) return;
+      if (renderedRef.current || errored) return;
       renderedRef.current = true;
       if (globalProps) {
         lynxView.updateGlobalProps(
@@ -151,13 +196,20 @@ export function useLynxStage({
       reportReadyEvent();
     }, 0);
 
-    return () => clearTimeout(t);
+    return () => {
+      clearTimeout(t);
+      (lynxView as unknown as HTMLElement).removeEventListener(
+        'error',
+        onError,
+      );
+    };
   }, [
     ready,
     entry,
     bundleRoot,
     globalProps,
     reportReadyEvent,
+    reportErrorEvent,
   ]);
 
   return {

--- a/packages/luna-stage/src/types/lynx-view.ts
+++ b/packages/luna-stage/src/types/lynx-view.ts
@@ -5,6 +5,7 @@
 import type { DetailedHTMLProps, HTMLAttributes } from 'react';
 
 type LynxViewAttributes = HTMLAttributes<HTMLElement> & {
+  url?: string;
   'lynx-group-id'?: number;
   'transform-vh'?: boolean;
   'transform-vw'?: boolean;


### PR DESCRIPTION
Setting `url` via a ref/property in an effect races with `<lynx-view>` upgrade/handshake, especially on mobile Safari/Chrome, which can leave the bundle unloaded.
- Compute and return `src` from `useLynxStage` during render
- Gate `<lynx-view>` mount on runtime `ready`
- Pass `url={src}` as a JSX attribute and remount on `key={src}`
- Remove dimsReady/ResizeObserver/browserConfig initialization paths
- Reset `renderedRef` on `src` change to match remount signal (supports cache-busting)
- Extend JSX intrinsic types to include the `url` attribute

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a race condition in Lynx view initialization by properly timing URL assignment and runtime readiness.

* **New Features**
  * Added support for setting the Lynx view URL via JSX attributes and improved initialization sequencing.
  * Added a new vanilla Lynx demo showcasing initialization approaches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dugyu/lunarium/pull/122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->