### PR TITLE
test(luna-stage): stub lynx-view updateGlobalProps in jsdom mock

### DIFF
--- a/.changeset/lynx-stage-url-attribute.md
+++ b/.changeset/lynx-stage-url-attribute.md
@@ -2,4 +2,9 @@
 "@dugyu/luna-stage": patch
 ---
 
-Fix `<lynx-view>` initialization race by setting `url` via JSX attribute and mounting only after the Lynx runtime is ready. Expose `src` and `ready` from `useLynxStage` to support this flow.
+Fix intermittent `<lynx-view>` load races by:
+
+- Mounting `<lynx-view>` only after the Lynx runtime is ready and the custom element is defined
+- Passing `url` via JSX attribute at element creation time (avoid ref/effect timing races)
+- Exposing `src` and `ready` from `useLynxStage` to support the safer mounting flow
+- Forwarding `<lynx-view>` `error` events to `onError` to avoid false-positive `onReady`

--- a/packages/luna-stage/src/lynx/__tests__/lynx-stage-hydration.test.tsx
+++ b/packages/luna-stage/src/lynx/__tests__/lynx-stage-hydration.test.tsx
@@ -21,7 +21,9 @@ vi.mock('@lynx-js/web-core/client', () => {
   ) {
     customElements.define(
       'lynx-view',
-      class LynxViewMock extends HTMLElement {},
+      class LynxViewMock extends HTMLElement {
+        updateGlobalProps = vi.fn();
+      },
     );
   }
   return { default: {} };


### PR DESCRIPTION
The jsdom custom element mock for `<lynx-view>` did not implement `updateGlobalProps`, so the zero-delay timer in `useLynxStage` could throw an unhandled error during hydration tests in CI.
Add `updateGlobalProps` as a `vi.fn()` on the mocked element to match the runtime surface and keep Vitest runs deterministic.